### PR TITLE
Allow glitchless output configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - wip
+  pull_request:
+
+jobs:
+  test:
+    name: Compile and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  rustfmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for `PCF8575` ([#1]).
 - Added support for `PCA9538`.
+- Added `into_output_high()` for totem-pole output drivers.  In contrast to
+  `into_output()` this will immediately put the pin into a HIGH state, thus
+  preventing a short glitch between setting direction and pin value.
+
+### Changed
+- `into_output()` for totem-pole output drivers now puts the pin into a LOW
+  state without a glitch.  Previously, it would leave the pin in whatever state
+  it was last in (= most often the HIGH state).
 
 [#1]: https://github.com/Rahix/port-expander/pull/1
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -32,9 +32,14 @@ pub trait PortDriver {
 }
 
 pub trait PortDriverTotemPole: PortDriver {
-    fn set_direction(&mut self, mask: u32, dir: Direction) -> Result<(), Self::Error>;
+    /// Set the direction for all pins in `mask` to direction `dir`.
+    ///
+    /// To prevent electrical glitches, when making pins outputs, the `state` can be either `true`
+    /// or `false` to immediately put the pin HIGH or LOW upon switching.
+    fn set_direction(&mut self, mask: u32, dir: Direction, state: bool) -> Result<(), Self::Error>;
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Direction {
     Input,
     Output,

--- a/src/dev/pca9536.rs
+++ b/src/dev/pca9536.rs
@@ -75,9 +75,15 @@ impl<I2C: crate::I2cBus> crate::PortDriver for Driver<I2C> {
     type Error = I2C::BusError;
 
     fn set(&mut self, mask_high: u32, mask_low: u32) -> Result<(), Self::Error> {
+        let previous = self.out;
         self.out |= mask_high as u8;
         self.out &= !mask_low as u8;
-        self.i2c.write_reg(ADDRESS, Regs::OutputPort, self.out)
+        if self.out != previous {
+            self.i2c.write_reg(ADDRESS, Regs::OutputPort, self.out)
+        } else {
+            // don't do the transfer when nothing changed
+            Ok(())
+        }
     }
 
     fn is_set(&mut self, mask_high: u32, mask_low: u32) -> Result<u32, Self::Error> {
@@ -91,7 +97,22 @@ impl<I2C: crate::I2cBus> crate::PortDriver for Driver<I2C> {
 }
 
 impl<I2C: crate::I2cBus> crate::PortDriverTotemPole for Driver<I2C> {
-    fn set_direction(&mut self, mask: u32, dir: crate::Direction) -> Result<(), Self::Error> {
+    fn set_direction(
+        &mut self,
+        mask: u32,
+        dir: crate::Direction,
+        state: bool,
+    ) -> Result<(), Self::Error> {
+        // set state before switching direction to prevent glitch
+        if dir == crate::Direction::Output {
+            use crate::PortDriver;
+            if state {
+                self.set(mask, 0)?;
+            } else {
+                self.set(0, mask)?;
+            }
+        }
+
         let (mask_set, mask_clear) = match dir {
             crate::Direction::Input => (mask as u8, 0),
             crate::Direction::Output => (0, mask as u8),
@@ -109,6 +130,7 @@ mod tests {
     fn pca9536() {
         let expectations = [
             // pin setup io0
+            mock_i2c::Transaction::write(super::ADDRESS, vec![0x01, 0xfe]),
             mock_i2c::Transaction::write_read(super::ADDRESS, vec![0x03], vec![0xff]),
             mock_i2c::Transaction::write(super::ADDRESS, vec![0x03, 0xfe]),
             // pin setup io1
@@ -118,9 +140,9 @@ mod tests {
             mock_i2c::Transaction::write_read(super::ADDRESS, vec![0x03], vec![0xfc]),
             mock_i2c::Transaction::write(super::ADDRESS, vec![0x03, 0xfd]),
             // io1 writes
-            mock_i2c::Transaction::write(super::ADDRESS, vec![0x01, 0xfd]),
-            mock_i2c::Transaction::write(super::ADDRESS, vec![0x01, 0xff]),
-            mock_i2c::Transaction::write(super::ADDRESS, vec![0x01, 0xfd]),
+            mock_i2c::Transaction::write(super::ADDRESS, vec![0x01, 0xfc]),
+            mock_i2c::Transaction::write(super::ADDRESS, vec![0x01, 0xfe]),
+            mock_i2c::Transaction::write(super::ADDRESS, vec![0x01, 0xfc]),
             // io0 reads
             mock_i2c::Transaction::write_read(super::ADDRESS, vec![0x00], vec![0x01]),
             mock_i2c::Transaction::write_read(super::ADDRESS, vec![0x00], vec![0x00]),
@@ -131,7 +153,7 @@ mod tests {
         let pca_pins = pca.split();
 
         let io0 = pca_pins.io0.into_output().unwrap();
-        let mut io1 = pca_pins.io1.into_output().unwrap();
+        let mut io1 = pca_pins.io1.into_output_high().unwrap();
 
         let io0 = io0.into_input().unwrap();
 

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -41,7 +41,7 @@ where
 {
     pub fn into_input(self) -> Result<Pin<'a, crate::mode::Input, MUTEX>, PD::Error> {
         self.port_driver
-            .lock(|drv| drv.set_direction(self.pin_mask, crate::Direction::Input))?;
+            .lock(|drv| drv.set_direction(self.pin_mask, crate::Direction::Input, false))?;
         Ok(Pin {
             pin_mask: self.pin_mask,
             port_driver: self.port_driver,
@@ -51,7 +51,17 @@ where
 
     pub fn into_output(self) -> Result<Pin<'a, crate::mode::Output, MUTEX>, PD::Error> {
         self.port_driver
-            .lock(|drv| drv.set_direction(self.pin_mask, crate::Direction::Output))?;
+            .lock(|drv| drv.set_direction(self.pin_mask, crate::Direction::Output, false))?;
+        Ok(Pin {
+            pin_mask: self.pin_mask,
+            port_driver: self.port_driver,
+            _m: PhantomData,
+        })
+    }
+
+    pub fn into_output_high(self) -> Result<Pin<'a, crate::mode::Output, MUTEX>, PD::Error> {
+        self.port_driver
+            .lock(|drv| drv.set_direction(self.pin_mask, crate::Direction::Output, true))?;
         Ok(Pin {
             pin_mask: self.pin_mask,
             port_driver: self.port_driver,


### PR DESCRIPTION
When configuring a pin as output, it was previously not possible to glitchlessly bring the pin into the desired electrical state.  For lots of control usecases, this is a very important feature.

Change the semantics of `into_output()` such that it always puts the pin into a LOW state.  Add a new `into_output_high()` which always puts the pin into a HIGH state.

I am going to mark this as a breaking change because existing code might rely on the fact that `into_output()` previously didn't touch the pin state...