### PR TITLE
Drop `shared-bus` dependency and replace it with custom mutex trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ std = []
 [dependencies]
 critical-section = { version = "1.1.2", optional = true }
 embedded-hal = { version = "1.0.0" }
-shared-bus = "0.3.0"
 
 [dev-dependencies]
 embedded-hal-mock = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2021"
 std = []
 
 [dependencies]
+critical-section = { version = "1.1.2", optional = true }
 embedded-hal = { version = "1.0.0" }
 shared-bus = "0.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Rahix <rahix@rahix.de>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rahix/port-expander"
 readme = "README.md"
-keywords = ["i2c", "shared-bus", "pca", "pcf", "gpio"]
+keywords = ["i2c", "gpio-expander", "gpio", "pca", "pcf"]
 categories = ["embedded", "no-std", "hardware-support"]
 
 version = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ version = "0.4.1"
 
 edition = "2021"
 
+[features]
+std = []
+
 [dependencies]
 embedded-hal = { version = "1.0.0" }
 shared-bus = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ a similar existing implementation as inspiration.  Contributions welcome!
 - [`PI4IOE5V6408`](https://docs.rs/port-expander/latest/port_expander/dev/pi4ioe5v6408/struct.Pi4ioe5v6408.html)
 
 ## Non-local sharing
-`port-expander` uses the `BusMutex` from
-[`shared-bus`](https://crates.io/crates/shared-bus) under the hood.  This means
-you can also make the pins shareable across task/thread boundaries, given that
-you provide an appropriate mutex type:
+`port-expander` uses a custom trait for abstracting different kinds of mutexes:
+[`PortMutex`](https://docs.rs/port-expander/latest/port_expander/trait.PortMutex.html).
+This means you can also make the pins shareable across task/thread boundaries,
+given that you provide an appropriate mutex type:
 
 ```rust
 // Initialize I2C peripheral from HAL

--- a/src/dev/max7321.rs
+++ b/src/dev/max7321.rs
@@ -2,7 +2,7 @@
 pub struct Max7321<M>(M);
 
 /// MAX7321 "I2C Port Expander with 8 Open-Drain I/Os"
-impl<I2C> Max7321<shared_bus::NullMutex<Driver<I2C>>>
+impl<I2C> Max7321<core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
 {
@@ -14,12 +14,10 @@ where
 impl<I2C, M> Max7321<M>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub fn with_mutex(i2c: I2C, a3: bool, a2: bool, a1: bool, a0: bool) -> Self {
-        Self(shared_bus::BusMutex::create(Driver::new(
-            i2c, a3, a2, a1, a0,
-        )))
+        Self(crate::PortMutex::create(Driver::new(i2c, a3, a2, a1, a0)))
     }
 
     pub fn split(&mut self) -> Parts<'_, I2C, M> {
@@ -36,10 +34,10 @@ where
     }
 }
 
-pub struct Parts<'a, I2C, M = shared_bus::NullMutex<Driver<I2C>>>
+pub struct Parts<'a, I2C, M = core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub p0: crate::Pin<'a, crate::mode::QuasiBidirectional, M>,
     pub p1: crate::Pin<'a, crate::mode::QuasiBidirectional, M>,

--- a/src/dev/pca9536.rs
+++ b/src/dev/pca9536.rs
@@ -4,7 +4,7 @@ use crate::I2cExt;
 /// `PCA9536` "4-bit I2C-bus and SMBus I/O port"
 pub struct Pca9536<M>(M);
 
-impl<I2C> Pca9536<shared_bus::NullMutex<Driver<I2C>>>
+impl<I2C> Pca9536<core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
 {
@@ -16,10 +16,10 @@ where
 impl<I2C, M> Pca9536<M>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub fn with_mutex(i2c: I2C) -> Self {
-        Self(shared_bus::BusMutex::create(Driver::new(i2c)))
+        Self(crate::PortMutex::create(Driver::new(i2c)))
     }
 
     pub fn split(&mut self) -> Parts<'_, I2C, M> {
@@ -32,10 +32,10 @@ where
     }
 }
 
-pub struct Parts<'a, I2C, M = shared_bus::NullMutex<Driver<I2C>>>
+pub struct Parts<'a, I2C, M = core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub io0: crate::Pin<'a, crate::mode::Input, M>,
     pub io1: crate::Pin<'a, crate::mode::Input, M>,

--- a/src/dev/pca9538.rs
+++ b/src/dev/pca9538.rs
@@ -4,7 +4,7 @@ use crate::I2cExt;
 /// `PCA9538` "Remote 8-Bit I2C AND SMBus Low-power I/O Expander"
 pub struct Pca9538<M>(M);
 
-impl<I2C> Pca9538<shared_bus::NullMutex<Driver<I2C>>>
+impl<I2C> Pca9538<core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
 {
@@ -16,10 +16,10 @@ where
 impl<I2C, M> Pca9538<M>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub fn with_mutex(i2c: I2C, a0: bool, a1: bool) -> Self {
-        Self(shared_bus::BusMutex::create(Driver::new(i2c, a0, a1)))
+        Self(crate::PortMutex::create(Driver::new(i2c, a0, a1)))
     }
 
     pub fn split(&mut self) -> Parts<'_, I2C, M> {
@@ -36,10 +36,10 @@ where
     }
 }
 
-pub struct Parts<'a, I2C, M = shared_bus::NullMutex<Driver<I2C>>>
+pub struct Parts<'a, I2C, M = core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub io0: crate::Pin<'a, crate::mode::Input, M>,
     pub io1: crate::Pin<'a, crate::mode::Input, M>,

--- a/src/dev/pca9555.rs
+++ b/src/dev/pca9555.rs
@@ -4,7 +4,7 @@ use crate::I2cExt;
 /// `PCA9555` "16-bit I2C-bus and SMBus I/O port with interrupt"
 pub struct Pca9555<M>(M);
 
-impl<I2C> Pca9555<shared_bus::NullMutex<Driver<I2C>>>
+impl<I2C> Pca9555<core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
 {
@@ -16,10 +16,10 @@ where
 impl<I2C, M> Pca9555<M>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub fn with_mutex(i2c: I2C, a0: bool, a1: bool, a2: bool) -> Self {
-        Self(shared_bus::BusMutex::create(Driver::new(i2c, a0, a1, a2)))
+        Self(crate::PortMutex::create(Driver::new(i2c, a0, a1, a2)))
     }
 
     pub fn split(&mut self) -> Parts<'_, I2C, M> {
@@ -44,10 +44,10 @@ where
     }
 }
 
-pub struct Parts<'a, I2C, M = shared_bus::NullMutex<Driver<I2C>>>
+pub struct Parts<'a, I2C, M = core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub io0_0: crate::Pin<'a, crate::mode::Input, M>,
     pub io0_1: crate::Pin<'a, crate::mode::Input, M>,

--- a/src/dev/pcal6408a.rs
+++ b/src/dev/pcal6408a.rs
@@ -4,7 +4,7 @@ use crate::I2cExt;
 /// `PCAL6408A` "8-bit I2C-bus and SMBus I/O port with interrupt"
 pub struct Pcal6408a<M>(M);
 
-impl<I2C> Pcal6408a<shared_bus::NullMutex<Driver<I2C>>>
+impl<I2C> Pcal6408a<core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
 {
@@ -16,10 +16,10 @@ where
 impl<I2C, M> Pcal6408a<M>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub fn with_mutex(i2c: I2C, addr: bool) -> Self {
-        Self(shared_bus::BusMutex::create(Driver::new(i2c, addr)))
+        Self(crate::PortMutex::create(Driver::new(i2c, addr)))
     }
 
     pub fn split(&mut self) -> Parts<'_, I2C, M> {
@@ -36,10 +36,10 @@ where
     }
 }
 
-pub struct Parts<'a, I2C, M = shared_bus::NullMutex<Driver<I2C>>>
+pub struct Parts<'a, I2C, M = core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub io0: crate::Pin<'a, crate::mode::Input, M>,
     pub io1: crate::Pin<'a, crate::mode::Input, M>,

--- a/src/dev/pcal6416a.rs
+++ b/src/dev/pcal6416a.rs
@@ -4,7 +4,7 @@ use crate::I2cExt;
 /// `PCAL6416A` "16-bit I2C-bus and SMBus I/O port with interrupt"
 pub struct Pcal6416a<M>(M);
 
-impl<I2C> Pcal6416a<shared_bus::NullMutex<Driver<I2C>>>
+impl<I2C> Pcal6416a<core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
 {
@@ -16,10 +16,10 @@ where
 impl<I2C, M> Pcal6416a<M>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub fn with_mutex(i2c: I2C, addr: bool) -> Self {
-        Self(shared_bus::BusMutex::create(Driver::new(i2c, addr)))
+        Self(crate::PortMutex::create(Driver::new(i2c, addr)))
     }
 
     pub fn split(&mut self) -> Parts<'_, I2C, M> {
@@ -44,10 +44,10 @@ where
     }
 }
 
-pub struct Parts<'a, I2C, M = shared_bus::NullMutex<Driver<I2C>>>
+pub struct Parts<'a, I2C, M = core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub io0_0: crate::Pin<'a, crate::mode::Input, M>,
     pub io0_1: crate::Pin<'a, crate::mode::Input, M>,

--- a/src/dev/pcf8574.rs
+++ b/src/dev/pcf8574.rs
@@ -5,7 +5,7 @@ pub struct Pcf8574<M>(M);
 /// `PCF8574A` "Remote 8-bit I/O expander for I2C-bus with interrupt"
 pub struct Pcf8574a<M>(M);
 
-impl<I2C> Pcf8574<shared_bus::NullMutex<Driver<I2C>>>
+impl<I2C> Pcf8574<core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
 {
@@ -14,7 +14,7 @@ where
     }
 }
 
-impl<I2C> Pcf8574a<shared_bus::NullMutex<Driver<I2C>>>
+impl<I2C> Pcf8574a<core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
 {
@@ -26,10 +26,10 @@ where
 impl<I2C, M> Pcf8574<M>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub fn with_mutex(i2c: I2C, a0: bool, a1: bool, a2: bool) -> Self {
-        Self(shared_bus::BusMutex::create(Driver::new(
+        Self(crate::PortMutex::create(Driver::new(
             i2c, false, a0, a1, a2,
         )))
     }
@@ -51,12 +51,10 @@ where
 impl<I2C, M> Pcf8574a<M>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub fn with_mutex(i2c: I2C, a0: bool, a1: bool, a2: bool) -> Self {
-        Self(shared_bus::BusMutex::create(Driver::new(
-            i2c, true, a0, a1, a2,
-        )))
+        Self(crate::PortMutex::create(Driver::new(i2c, true, a0, a1, a2)))
     }
 
     pub fn split(&mut self) -> Parts<'_, I2C, M> {
@@ -73,10 +71,10 @@ where
     }
 }
 
-pub struct Parts<'a, I2C, M = shared_bus::NullMutex<Driver<I2C>>>
+pub struct Parts<'a, I2C, M = core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub p0: crate::Pin<'a, crate::mode::QuasiBidirectional, M>,
     pub p1: crate::Pin<'a, crate::mode::QuasiBidirectional, M>,

--- a/src/dev/pcf8575.rs
+++ b/src/dev/pcf8575.rs
@@ -3,7 +3,7 @@
 /// `PCF8575` "Remote 16-bit I/O expander for I2C-bus with interrupt"
 pub struct Pcf8575<M>(M);
 
-impl<I2C> Pcf8575<shared_bus::NullMutex<Driver<I2C>>>
+impl<I2C> Pcf8575<core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
 {
@@ -15,10 +15,10 @@ where
 impl<I2C, M> Pcf8575<M>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub fn with_mutex(i2c: I2C, a0: bool, a1: bool, a2: bool) -> Self {
-        Self(shared_bus::BusMutex::create(Driver::new(i2c, a0, a1, a2)))
+        Self(crate::PortMutex::create(Driver::new(i2c, a0, a1, a2)))
     }
 
     pub fn split(&mut self) -> Parts<'_, I2C, M> {
@@ -43,10 +43,10 @@ where
     }
 }
 
-pub struct Parts<'a, I2C, M = shared_bus::NullMutex<Driver<I2C>>>
+pub struct Parts<'a, I2C, M = core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub p00: crate::Pin<'a, crate::mode::QuasiBidirectional, M>,
     pub p01: crate::Pin<'a, crate::mode::QuasiBidirectional, M>,

--- a/src/dev/tca6408a.rs
+++ b/src/dev/tca6408a.rs
@@ -4,7 +4,7 @@ use crate::I2cExt;
 /// `TCA6408A` "Remote 8-Bit I2C AND SMBus Low-power I/O Expander"
 pub struct Tca6408a<M>(M);
 
-impl<I2C> Tca6408a<shared_bus::NullMutex<Driver<I2C>>>
+impl<I2C> Tca6408a<core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
 {
@@ -16,10 +16,10 @@ where
 impl<I2C, M> Tca6408a<M>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub fn with_mutex(i2c: I2C, a0: bool) -> Self {
-        Self(shared_bus::BusMutex::create(Driver::new(i2c, a0)))
+        Self(crate::PortMutex::create(Driver::new(i2c, a0)))
     }
 
     pub fn split(&mut self) -> Parts<'_, I2C, M> {
@@ -36,10 +36,10 @@ where
     }
 }
 
-pub struct Parts<'a, I2C, M = shared_bus::NullMutex<Driver<I2C>>>
+pub struct Parts<'a, I2C, M = core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
-    M: shared_bus::BusMutex<Bus = Driver<I2C>>,
+    M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub io0: crate::Pin<'a, crate::mode::Input, M>,
     pub io1: crate::Pin<'a, crate::mode::Input, M>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //! let pca_pins = pca9555.split();
 //! ```
 
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 
 mod bus;
 mod common;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@
 //! - [`TCA6408A`](Tca6408a)
 //!
 //! ## Non-local sharing
-//! `port-expander` uses the `BusMutex` from [`shared-bus`](https://crates.io/crates/shared-bus)
-//! under the hood.  This means you can also make the pins shareable across task/thread boundaries,
+//! `port-expander` uses a custom trait for abstracting different kinds of mutexes:
+//! [`PortMutex`]. This means you can also make the pins shareable across task/thread boundaries,
 //! given that you provide an appropriate mutex type:
 //!
 //! ```ignore

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,12 +61,14 @@ mod bus;
 mod common;
 pub mod dev;
 mod multi;
+mod mutex;
 mod pin;
 
 pub use bus::I2cBus;
 pub use common::mode;
 pub use multi::read_multiple;
 pub use multi::write_multiple;
+pub use mutex::PortMutex;
 pub use pin::Pin;
 
 pub(crate) use bus::I2cExt;

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -34,7 +34,7 @@ pub fn write_multiple<PD, MUTEX, MODE: crate::mode::HasOutput, const N: usize>(
 ) -> Result<(), PD::Error>
 where
     PD: crate::PortDriver,
-    MUTEX: shared_bus::BusMutex<Bus = PD>,
+    MUTEX: crate::PortMutex<Port = PD>,
 {
     let mut mask_set_high = 0x00;
     let mut mask_set_low = 0x00;
@@ -98,7 +98,7 @@ pub fn read_multiple<PD, MUTEX, MODE: crate::mode::HasInput, const N: usize>(
 ) -> Result<[bool; N], PD::Error>
 where
     PD: crate::PortDriver,
-    MUTEX: shared_bus::BusMutex<Bus = PD>,
+    MUTEX: crate::PortMutex<Port = PD>,
 {
     let mask = pins.iter().map(|p| p.pin_mask()).fold(0, |m, p| m | p);
     let port_driver = pins[0].port_driver();

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -1,0 +1,54 @@
+/// Common interface for mutex implementations.
+///
+/// `port-expander` needs a mutex to ensure only a single pin object can access the port-expander at the same time,
+/// in concurrent situations.  `port-expander` already implements this trait for a number of existing
+/// mutex types.  Most of them are guarded by a feature that needs to be enabled.  Here is an
+/// overview:
+///
+/// | Mutex | Feature Name | Notes |
+/// | --- | --- | --- |
+/// | [`core::cell::RefCell`] | _always available_ | For sharing within a single execution context. |
+///
+/// For other mutex types, a custom implementation is needed.  Due to the orphan rule, it might be
+/// necessary to wrap it in a newtype.  As an example, this is what such a custom implementation
+/// might look like:
+///
+/// ```
+/// struct MyMutex<T>(std::sync::Mutex<T>);
+///
+/// impl<T> port_expander::PortMutex for MyMutex<T> {
+///     type Port = T;
+///
+///     fn create(v: T) -> Self {
+///         Self(std::sync::Mutex::new(v))
+///     }
+///
+///     fn lock<R, F: FnOnce(&mut Self::Port) -> R>(&self, f: F) -> R {
+///         let mut v = self.0.lock().unwrap();
+///         f(&mut v)
+///     }
+/// }
+/// ```
+pub trait PortMutex {
+    /// The actual port-expander that is wrapped inside this mutex.
+    type Port;
+
+    /// Create a new mutex of this type.
+    fn create(v: Self::Port) -> Self;
+
+    /// Lock the mutex and give a closure access to the port-expander inside.
+    fn lock<R, F: FnOnce(&mut Self::Port) -> R>(&self, f: F) -> R;
+}
+
+impl<T> PortMutex for core::cell::RefCell<T> {
+    type Port = T;
+
+    fn create(v: Self::Port) -> Self {
+        core::cell::RefCell::new(v)
+    }
+
+    fn lock<R, F: FnOnce(&mut Self::Port) -> R>(&self, f: F) -> R {
+        let mut v = self.borrow_mut();
+        f(&mut v)
+    }
+}

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -14,7 +14,7 @@ pub struct Pin<'a, MODE, MUTEX> {
 impl<'a, MODE, MUTEX, PD> Pin<'a, MODE, MUTEX>
 where
     PD: crate::PortDriver,
-    MUTEX: shared_bus::BusMutex<Bus = PD>,
+    MUTEX: crate::PortMutex<Port = PD>,
 {
     pub(crate) fn new(pin_number: u8, port_driver: &'a MUTEX) -> Self {
         assert!(pin_number < 32);
@@ -37,14 +37,14 @@ impl<'a, MODE, MUTEX, PD> ErrorType for Pin<'a, MODE, MUTEX>
 where
     PD: crate::PortDriver + crate::PortDriverTotemPole,
     PD::Error: embedded_hal::digital::Error,
-    MUTEX: shared_bus::BusMutex<Bus = PD>,
+    MUTEX: crate::PortMutex<Port = PD>,
 {
     type Error = PD::Error;
 }
 impl<'a, MODE, MUTEX, PD> Pin<'a, MODE, MUTEX>
 where
     PD: crate::PortDriver + crate::PortDriverTotemPole,
-    MUTEX: shared_bus::BusMutex<Bus = PD>,
+    MUTEX: crate::PortMutex<Port = PD>,
 {
     /// Configure this pin as an input.
     ///
@@ -91,7 +91,7 @@ where
 impl<'a, MODE, MUTEX, PD> Pin<'a, MODE, MUTEX>
 where
     PD: crate::PortDriver + crate::PortDriverPolarity,
-    MUTEX: shared_bus::BusMutex<Bus = PD>,
+    MUTEX: crate::PortMutex<Port = PD>,
 {
     /// Turn on hardware polarity inversion for this pin.
     pub fn into_inverted(self) -> Result<Self, PD::Error> {
@@ -111,7 +111,7 @@ where
 impl<'a, MODE: crate::mode::HasInput, MUTEX, PD> Pin<'a, MODE, MUTEX>
 where
     PD: crate::PortDriver,
-    MUTEX: shared_bus::BusMutex<Bus = PD>,
+    MUTEX: crate::PortMutex<Port = PD>,
 {
     /// Read the pin's input state and return `true` if it is HIGH.
     pub fn is_high(&self) -> Result<bool, PD::Error> {
@@ -130,7 +130,7 @@ impl<'a, MODE: crate::mode::HasInput, MUTEX, PD> hal_digital::InputPin for Pin<'
 where
     PD: crate::PortDriver + crate::PortDriverTotemPole,
     <PD as crate::PortDriver>::Error: embedded_hal::digital::Error,
-    MUTEX: shared_bus::BusMutex<Bus = PD>,
+    MUTEX: crate::PortMutex<Port = PD>,
 {
     fn is_high(&mut self) -> Result<bool, <PD as crate::PortDriver>::Error> {
         Pin::is_high(self)
@@ -144,7 +144,7 @@ where
 impl<'a, MODE: crate::mode::HasOutput, MUTEX, PD> Pin<'a, MODE, MUTEX>
 where
     PD: crate::PortDriver,
-    MUTEX: shared_bus::BusMutex<Bus = PD>,
+    MUTEX: crate::PortMutex<Port = PD>,
 {
     /// Set the pin's output state to HIGH.
     ///
@@ -186,7 +186,7 @@ impl<'a, MODE: crate::mode::HasOutput, MUTEX, PD> hal_digital::OutputPin for Pin
 where
     PD: crate::PortDriver + crate::PortDriverTotemPole,
     <PD as crate::PortDriver>::Error: embedded_hal::digital::Error,
-    MUTEX: shared_bus::BusMutex<Bus = PD>,
+    MUTEX: crate::PortMutex<Port = PD>,
 {
     fn set_low(&mut self) -> Result<(), Self::Error> {
         Pin::set_low(self)
@@ -202,7 +202,7 @@ impl<'a, MODE: crate::mode::HasOutput, MUTEX, PD> hal_digital::StatefulOutputPin
 where
     PD: crate::PortDriver + crate::PortDriverTotemPole,
     <PD as crate::PortDriver>::Error: embedded_hal::digital::Error,
-    MUTEX: shared_bus::BusMutex<Bus = PD>,
+    MUTEX: crate::PortMutex<Port = PD>,
 {
     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
         Pin::is_set_high(self)


### PR DESCRIPTION
Closes #25.

I'd appreciate testing to make sure we're not breaking downstream applications too much.  @t-moe, maybe you can give this branch a spin?