### PR TITLE
Wrap errors for embedded-hal trait implementations

### DIFF
--- a/src/pin.rs
+++ b/src/pin.rs
@@ -40,14 +40,36 @@ where
         self.port_driver.lock(|pd| f(pd))
     }
 }
+
+#[derive(Debug)]
+pub struct PinError<BE> {
+    pub bus_error: BE,
+}
+
+impl<BE> hal_digital::Error for PinError<BE>
+where
+    BE: core::fmt::Debug,
+{
+    fn kind(&self) -> hal_digital::ErrorKind {
+        hal_digital::ErrorKind::Other
+    }
+}
+
+impl<BE> From<BE> for PinError<BE> {
+    fn from(value: BE) -> Self {
+        Self { bus_error: value }
+    }
+}
+
 impl<'a, MODE, MUTEX, PD> ErrorType for Pin<'a, MODE, MUTEX>
 where
     PD: crate::PortDriver + crate::PortDriverTotemPole,
-    PD::Error: embedded_hal::digital::Error,
+    PD::Error: core::fmt::Debug,
     MUTEX: crate::PortMutex<Port = PD>,
 {
-    type Error = PD::Error;
+    type Error = PinError<PD::Error>;
 }
+
 impl<'a, MODE, MUTEX, PD> Pin<'a, MODE, MUTEX>
 where
     PD: crate::PortDriver + crate::PortDriverTotemPole,
@@ -164,15 +186,15 @@ where
 impl<'a, MODE: crate::mode::HasInput, MUTEX, PD> hal_digital::InputPin for Pin<'a, MODE, MUTEX>
 where
     PD: crate::PortDriver + crate::PortDriverTotemPole,
-    <PD as crate::PortDriver>::Error: embedded_hal::digital::Error,
+    <PD as crate::PortDriver>::Error: core::fmt::Debug,
     MUTEX: crate::PortMutex<Port = PD>,
 {
-    fn is_high(&mut self) -> Result<bool, <PD as crate::PortDriver>::Error> {
-        Pin::is_high(self)
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(Pin::is_high(self)?)
     }
 
-    fn is_low(&mut self) -> Result<bool, <PD as crate::PortDriver>::Error> {
-        Pin::is_low(self)
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(Pin::is_low(self)?)
     }
 }
 
@@ -220,15 +242,15 @@ where
 impl<'a, MODE: crate::mode::HasOutput, MUTEX, PD> hal_digital::OutputPin for Pin<'a, MODE, MUTEX>
 where
     PD: crate::PortDriver + crate::PortDriverTotemPole,
-    <PD as crate::PortDriver>::Error: embedded_hal::digital::Error,
+    <PD as crate::PortDriver>::Error: core::fmt::Debug,
     MUTEX: crate::PortMutex<Port = PD>,
 {
     fn set_low(&mut self) -> Result<(), Self::Error> {
-        Pin::set_low(self)
+        Ok(Pin::set_low(self)?)
     }
 
     fn set_high(&mut self) -> Result<(), Self::Error> {
-        Pin::set_high(self)
+        Ok(Pin::set_high(self)?)
     }
 }
 
@@ -236,18 +258,18 @@ impl<'a, MODE: crate::mode::HasOutput, MUTEX, PD> hal_digital::StatefulOutputPin
     for Pin<'a, MODE, MUTEX>
 where
     PD: crate::PortDriver + crate::PortDriverTotemPole,
-    <PD as crate::PortDriver>::Error: embedded_hal::digital::Error,
+    <PD as crate::PortDriver>::Error: core::fmt::Debug,
     MUTEX: crate::PortMutex<Port = PD>,
 {
     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
-        Pin::is_set_high(self)
+        Ok(Pin::is_set_high(self)?)
     }
 
     fn is_set_low(&mut self) -> Result<bool, Self::Error> {
-        Pin::is_set_low(self)
+        Ok(Pin::is_set_low(self)?)
     }
 
     fn toggle(&mut self) -> Result<(), Self::Error> {
-        Pin::toggle(self)
+        Ok(Pin::toggle(self)?)
     }
 }

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -41,23 +41,33 @@ where
     }
 }
 
+/// Error type for [`Pin`] which implements [`embedded_hal::digital::Error`].
 #[derive(Debug)]
-pub struct PinError<BE> {
-    pub bus_error: BE,
+pub struct PinError<PDE> {
+    driver_error: PDE,
 }
 
-impl<BE> hal_digital::Error for PinError<BE>
+impl<PDE> PinError<PDE> {
+    /// The upstream port driver error that occurred
+    pub fn driver_error(&self) -> &PDE {
+        &self.driver_error
+    }
+}
+
+impl<PDE> hal_digital::Error for PinError<PDE>
 where
-    BE: core::fmt::Debug,
+    PDE: core::fmt::Debug,
 {
     fn kind(&self) -> hal_digital::ErrorKind {
         hal_digital::ErrorKind::Other
     }
 }
 
-impl<BE> From<BE> for PinError<BE> {
-    fn from(value: BE) -> Self {
-        Self { bus_error: value }
+impl<PDE> From<PDE> for PinError<PDE> {
+    fn from(value: PDE) -> Self {
+        Self {
+            driver_error: value,
+        }
     }
 }
 


### PR DESCRIPTION
The current implementations of the `OutputPin`, `InputPin` and `StatefulOutputPin` traits require that `PortDriver::Error` implements `embedded_hal::digital::Error`, which is never going to be the case. Thus, these traits are never usable.

Here is a small example that should result in lots of compiler errors because of unsatisfied trait bounds:
```rust
use embedded_hal::digital::{InputPin, OutputPin};

fn main() {
    let mut expander =
        port_expander::Tca6408a::new(embedded_hal_mock::eh1::i2c::Mock::new(&[]), false);
    let pins = expander.split();

    let mut pin0 = pins.io0.into_output().unwrap();
    let pin1 = pins.io1.into_input().unwrap();

    println!("Is pin1 low? {}", pin1.is_low().unwrap());
    print_it(pin1).unwrap();

    pin0.set_low().unwrap();
    set_it_high(pin0).unwrap();
}

fn set_it_high<P>(mut pin: P) -> Result<(), P::Error>
where
    P: OutputPin,
{
    pin.set_high()?;

    Ok(())
}

fn print_it<P>(mut pin: P) -> Result<(), P::Error>
where
    P: InputPin,
{
    println!("Pin: {}", pin.is_high()?);

    Ok(())
}
```

This change wraps the error type used in `ErrorKind::Error` in a wrapper struct `PinError<BE>` which implements `embedded_hal::digital::Error`. Like this all upstream errors that are `core::fmt::Debug` should be compatible with `embedded-hal`.

The return types for `Pin::set_high()` and `OutputPin::set_high()` are different now, since the returned error from the `Pin` implementation do not wrap errors in `PinError`. This could cause problems, so maybe it's a good idea to wrap these errors as well?