### PR TITLE
Implement `PortDriverPullUp` and `PortDriverPolarity` for Mcp23x17

### DIFF
--- a/src/dev/mcp23x17.rs
+++ b/src/dev/mcp23x17.rs
@@ -260,6 +260,32 @@ impl<B: Mcp23x17Bus> crate::PortDriverTotemPole for Driver<B> {
     }
 }
 
+impl<B: Mcp23x17Bus> crate::PortDriverPullUp for Driver<B> {
+    fn set_pull_up(&mut self, mask: u32, enable: bool) -> Result<(), Self::Error> {
+        let (mask_set, mask_clear) = match enable {
+            true => (mask as u16, 0),
+            false => (0, mask as u16),
+        };
+        if mask & 0x00FF != 0 {
+            self.bus.update_reg(
+                self.addr,
+                Regs::GPPUA,
+                (mask_set & 0xFF) as u8,
+                (mask_clear & 0xFF) as u8,
+            )?;
+        }
+        if mask & 0xFF00 != 0 {
+            self.bus.update_reg(
+                self.addr,
+                Regs::GPPUB,
+                (mask_set >> 8) as u8,
+                (mask_clear >> 8) as u8,
+            )?;
+        }
+        Ok(())
+    }
+}
+
 // We need these newtype wrappers since we can't implement `Mcp23x17Bus` for both `I2cBus` and `SpiBus`
 // at the same time
 pub struct Mcp23017Bus<I2C>(I2C);

--- a/src/dev/mcp23x17.rs
+++ b/src/dev/mcp23x17.rs
@@ -286,6 +286,32 @@ impl<B: Mcp23x17Bus> crate::PortDriverPullUp for Driver<B> {
     }
 }
 
+impl<B: Mcp23x17Bus> crate::PortDriverPolarity for Driver<B> {
+    fn set_polarity(&mut self, mask: u32, inverted: bool) -> Result<(), Self::Error> {
+        let (mask_set, mask_clear) = match inverted {
+            true => (mask as u16, 0),
+            false => (0, mask as u16),
+        };
+        if mask & 0x00FF != 0 {
+            self.bus.update_reg(
+                self.addr,
+                Regs::IPOLA,
+                (mask_set & 0xFF) as u8,
+                (mask_clear & 0xFF) as u8,
+            )?;
+        }
+        if mask & 0xFF00 != 0 {
+            self.bus.update_reg(
+                self.addr,
+                Regs::IPOLB,
+                (mask_set >> 8) as u8,
+                (mask_clear >> 8) as u8,
+            )?;
+        }
+        Ok(())
+    }
+}
+
 // We need these newtype wrappers since we can't implement `Mcp23x17Bus` for both `I2cBus` and `SpiBus`
 // at the same time
 pub struct Mcp23017Bus<I2C>(I2C);


### PR DESCRIPTION
Yet another PR :) The last pull request for the MCP23x17 was missing the implementation for pull-ups and polarity inversion, which are supported by this expander. So this adds the implementation for the `PortDriverPullUp`- and `PortDriverPolarity`-traits.

I only tested the pull-ups on real hardware so far, but I guess the polarity inversion is obvious enough that it should work as well.