### PR TITLE
Implement PortDriverTotemPole trait for devices which have no dedicated directions

### DIFF
--- a/src/dev/max7321.rs
+++ b/src/dev/max7321.rs
@@ -88,6 +88,18 @@ impl<I2C: crate::I2cBus> crate::PortDriver for Driver<I2C> {
     }
 }
 
+impl<I2C: crate::I2cBus> crate::PortDriverTotemPole for Driver<I2C> {
+    fn set_direction(
+        &mut self,
+        _mask: u32,
+        _dir: crate::Direction,
+        _state: bool,
+    ) -> Result<(), Self::Error> {
+        // max7321 does not have dedicated directions
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use embedded_hal_mock::eh1::i2c as mock_i2c;

--- a/src/dev/pcf8574.rs
+++ b/src/dev/pcf8574.rs
@@ -129,6 +129,18 @@ impl<I2C: crate::I2cBus> crate::PortDriver for Driver<I2C> {
     }
 }
 
+impl<I2C: crate::I2cBus> crate::PortDriverTotemPole for Driver<I2C> {
+    fn set_direction(
+        &mut self,
+        _mask: u32,
+        _dir: crate::Direction,
+        _state: bool,
+    ) -> Result<(), Self::Error> {
+        // pcf8574 does not have dedicated directions
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use embedded_hal_mock::eh1::i2c as mock_i2c;

--- a/src/dev/pcf8575.rs
+++ b/src/dev/pcf8575.rs
@@ -111,6 +111,18 @@ impl<I2C: crate::I2cBus> crate::PortDriver for Driver<I2C> {
     }
 }
 
+impl<I2C: crate::I2cBus> crate::PortDriverTotemPole for Driver<I2C> {
+    fn set_direction(
+        &mut self,
+        _mask: u32,
+        _dir: crate::Direction,
+        _state: bool,
+    ) -> Result<(), Self::Error> {
+        // pcf8575 does not have dedicated directions
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use embedded_hal_mock::eh1::i2c as mock_i2c;


### PR DESCRIPTION
This fixes my issue #33. The changed devices (pcf8574, pcf8575, max7321) do not have dedicated registers to change between input and output. So just implementing an empty ``set_direction`` function for the PortDriverTotemPole trait fixes the trait bound for OutputPin for these devices, without harming functionality.