### PR TITLE
Async functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.6.5"
 edition = "2021"
 
 [features]
-default = ["async"]
 std = []
 async = ["embedded-hal-async", "heapless"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,15 @@ version = "0.6.5"
 edition = "2021"
 
 [features]
+default = ["async"]
 std = []
+async = ["embedded-hal-async", "heapless"]
 
 [dependencies]
 critical-section = { version = "1.1.2", optional = true }
 embedded-hal = { version = "1.0.0" }
+embedded-hal-async = { version = "1.0.0", optional = true }
+heapless = {version = "0.8.0", optional = true }
 
 [dev-dependencies]
 embedded-hal-mock = "0.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.6.5"
 edition = "2021"
 
 [features]
+default = ["async"]
 std = []
 async = ["embedded-hal-async", "heapless"]
 
@@ -24,3 +25,7 @@ heapless = {version = "0.8.0", optional = true }
 
 [dev-dependencies]
 embedded-hal-mock = "0.11.1"
+
+[patch.crates-io]
+embedded-hal = { git = "https://github.com/rust-embedded/embedded-hal.git", package = "embedded-hal" }
+embedded-hal-async = { git = "https://github.com/rust-embedded/embedded-hal.git", package = "embedded-hal-async" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 [features]
 default = ["async"]
 std = []
-async = ["embedded-hal-async", "heapless"]
+async = ["embedded-hal-async", "heapless", "critical-section"]
 
 [dependencies]
 critical-section = { version = "1.1.2", optional = true }

--- a/src/dev/pca9554.rs
+++ b/src/dev/pca9554.rs
@@ -66,8 +66,8 @@ where
     /// to wake tasks waiting on pin changes.
     #[cfg(feature = "async")]
     pub fn split_async(
-        &mut self,
-    ) -> Result<PartsAsync<I2C, M>, <Driver<I2C> as crate::PortDriver>::Error> {
+        &'_ mut self,
+    ) -> Result<PartsAsync<'_, I2C, M>, <Driver<I2C> as crate::PortDriver>::Error> {
         // Read once so the async state won't see a spurious edge
         let initial_state = self.0.lock(|drv| drv.get(0xFF, 0))?;
         self.1.borrow_mut().last_known_state = initial_state;
@@ -116,8 +116,8 @@ where
     /// Async split, same as Pca9554 but for the 'A' variant.
     #[cfg(feature = "async")]
     pub fn split_async(
-        &mut self,
-    ) -> Result<PartsAsync<I2C, M>, <Driver<I2C> as crate::PortDriver>::Error> {
+        &'_ mut self,
+    ) -> Result<PartsAsync<'_, I2C, M>, <Driver<I2C> as crate::PortDriver>::Error> {
         let initial_state = self.0.lock(|drv| drv.get(0xFF, 0))?;
         self.1.borrow_mut().last_known_state = initial_state;
 

--- a/src/dev/pca9554.rs
+++ b/src/dev/pca9554.rs
@@ -44,7 +44,7 @@ where
         )
     }
 
-    pub fn split(&mut self) -> Parts<I2C, M> {
+    pub fn split(&'_ mut self) -> Parts<'_, I2C, M> {
         Parts {
             io0: crate::Pin::new(0, &self.0),
             io1: crate::Pin::new(1, &self.0),

--- a/src/dev/pca9554.rs
+++ b/src/dev/pca9554.rs
@@ -1,10 +1,17 @@
 //! Support for the `PCA9554` and `PCA9554a` "8-bit I2C-bus and SMBus I/O port with interrupt"
 use crate::I2cExt;
+use crate::PortDriver;
+
+#[cfg(feature = "async")]
+use crate::pin_async::{AsyncPortState, InterruptHandler, PinAsync};
+#[cfg(feature = "async")]
+use core::cell::RefCell;
 
 /// `PCA9554` "8-bit I2C-bus and SMBus I/O port with interrupt"
-pub struct Pca9554<M>(M);
+pub struct Pca9554<M>(pub M, #[cfg(feature = "async")] pub RefCell<AsyncPortState>);
+
 /// `PCA9554A` "8-bit I2C-bus and SMBus I/O port with interrupt"
-pub struct Pca9554A<M>(M);
+pub struct Pca9554A<M>(pub M, #[cfg(feature = "async")] pub RefCell<AsyncPortState>);
 
 impl<I2C> Pca9554<core::cell::RefCell<Driver<I2C>>>
 where
@@ -30,9 +37,11 @@ where
     M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub fn with_mutex(i2c: I2C, a0: bool, a1: bool, a2: bool) -> Self {
-        Self(crate::PortMutex::create(Driver::new(
-            i2c, false, a0, a1, a2,
-        )))
+        Self(
+            crate::PortMutex::create(Driver::new(i2c, false, a0, a1, a2)),
+            #[cfg(feature = "async")]
+            RefCell::new(AsyncPortState::new()),
+        )
     }
 
     pub fn split<'a>(&'a mut self) -> Parts<'a, I2C, M> {
@@ -47,6 +56,35 @@ where
             io7: crate::Pin::new(7, &self.0),
         }
     }
+
+    /// **Async** split: returns 8 async quasi-bidir pins plus an interrupt handler.
+    ///
+    /// 1. Performs an initial read to sync the `AsyncPortState`.
+    /// 2. Returns [`PartsAsync`] with `PinAsync`s and an [`InterruptHandler`].
+    ///
+    /// You must call `.handle_interrupts()` from your hardware ISR
+    /// to wake tasks waiting on pin changes.
+    #[cfg(feature = "async")]
+    pub fn split_async<'a>(
+        &'a mut self,
+    ) -> Result<PartsAsync<'a, I2C, M>, <Driver<I2C> as crate::PortDriver>::Error> {
+        // Read once so the async state won't see a spurious edge
+        let initial_state = self.0.lock(|drv| drv.get(0xFF, 0))?;
+        self.1.borrow_mut().last_known_state = initial_state;
+
+        Ok(PartsAsync {
+            io0: PinAsync::new(crate::Pin::new(0, &self.0), &self.1, 0),
+            io1: PinAsync::new(crate::Pin::new(1, &self.0), &self.1, 1),
+            io2: PinAsync::new(crate::Pin::new(2, &self.0), &self.1, 2),
+            io3: PinAsync::new(crate::Pin::new(3, &self.0), &self.1, 3),
+            io4: PinAsync::new(crate::Pin::new(4, &self.0), &self.1, 4),
+            io5: PinAsync::new(crate::Pin::new(5, &self.0), &self.1, 5),
+            io6: PinAsync::new(crate::Pin::new(6, &self.0), &self.1, 6),
+            io7: PinAsync::new(crate::Pin::new(7, &self.0), &self.1, 7),
+
+            interrupts: InterruptHandler::new(&self.0, &self.1),
+        })
+    }
 }
 
 impl<I2C, M> Pca9554A<M>
@@ -55,7 +93,11 @@ where
     M: crate::PortMutex<Port = Driver<I2C>>,
 {
     pub fn with_mutex(i2c: I2C, a0: bool, a1: bool, a2: bool) -> Self {
-        Self(crate::PortMutex::create(Driver::new(i2c, true, a0, a1, a2)))
+        Self(
+            crate::PortMutex::create(Driver::new(i2c, true, a0, a1, a2)),
+            #[cfg(feature = "async")]
+            RefCell::new(AsyncPortState::new()),
+        )
     }
 
     pub fn split(&mut self) -> Parts<'_, I2C, M> {
@@ -70,8 +112,31 @@ where
             io7: crate::Pin::new(7, &self.0),
         }
     }
+
+    /// Async split, same as Pca9554 but for the 'A' variant.
+    #[cfg(feature = "async")]
+    pub fn split_async<'a>(
+        &'a mut self,
+    ) -> Result<PartsAsync<'a, I2C, M>, <Driver<I2C> as crate::PortDriver>::Error> {
+        let initial_state = self.0.lock(|drv| drv.get(0xFF, 0))?;
+        self.1.borrow_mut().last_known_state = initial_state;
+
+        Ok(PartsAsync {
+            io0: PinAsync::new(crate::Pin::new(0, &self.0), &self.1, 0),
+            io1: PinAsync::new(crate::Pin::new(1, &self.0), &self.1, 1),
+            io2: PinAsync::new(crate::Pin::new(2, &self.0), &self.1, 2),
+            io3: PinAsync::new(crate::Pin::new(3, &self.0), &self.1, 3),
+            io4: PinAsync::new(crate::Pin::new(4, &self.0), &self.1, 4),
+            io5: PinAsync::new(crate::Pin::new(5, &self.0), &self.1, 5),
+            io6: PinAsync::new(crate::Pin::new(6, &self.0), &self.1, 6),
+            io7: PinAsync::new(crate::Pin::new(7, &self.0), &self.1, 7),
+
+            interrupts: InterruptHandler::new(&self.0, &self.1),
+        })
+    }
 }
 
+/// Container for all 8 pins (synchronous usage).
 pub struct Parts<'a, I2C, M = core::cell::RefCell<Driver<I2C>>>
 where
     I2C: crate::I2cBus,
@@ -85,6 +150,26 @@ where
     pub io5: crate::Pin<'a, crate::mode::QuasiBidirectional, M>,
     pub io6: crate::Pin<'a, crate::mode::QuasiBidirectional, M>,
     pub io7: crate::Pin<'a, crate::mode::QuasiBidirectional, M>,
+}
+
+#[cfg(feature = "async")]
+/// Container for all 8 pins in async form, plus the interrupt handler.
+pub struct PartsAsync<'a, I2C, M = core::cell::RefCell<Driver<I2C>>>
+where
+    I2C: crate::I2cBus,
+    M: crate::PortMutex<Port = Driver<I2C>>,
+{
+    pub io0: PinAsync<'a, crate::mode::QuasiBidirectional, M>,
+    pub io1: PinAsync<'a, crate::mode::QuasiBidirectional, M>,
+    pub io2: PinAsync<'a, crate::mode::QuasiBidirectional, M>,
+    pub io3: PinAsync<'a, crate::mode::QuasiBidirectional, M>,
+    pub io4: PinAsync<'a, crate::mode::QuasiBidirectional, M>,
+    pub io5: PinAsync<'a, crate::mode::QuasiBidirectional, M>,
+    pub io6: PinAsync<'a, crate::mode::QuasiBidirectional, M>,
+    pub io7: PinAsync<'a, crate::mode::QuasiBidirectional, M>,
+
+    /// Must be called from your real hardware interrupt to wake any waiting tasks.
+    pub interrupts: InterruptHandler<'a, M>,
 }
 
 #[allow(dead_code)]
@@ -158,7 +243,6 @@ impl<I2C: crate::I2cBus> crate::PortDriverTotemPole for Driver<I2C> {
     ) -> Result<(), Self::Error> {
         // set state before switching direction to prevent glitch
         if dir == crate::Direction::Output {
-            use crate::PortDriver;
             if state {
                 self.set(mask, 0)?;
             } else {

--- a/src/dev/pca9554.rs
+++ b/src/dev/pca9554.rs
@@ -3,15 +3,13 @@ use crate::I2cExt;
 use crate::PortDriver;
 
 #[cfg(feature = "async")]
-use crate::pin_async::{AsyncPortState, InterruptHandler, PinAsync};
-#[cfg(feature = "async")]
-use core::cell::RefCell;
+use crate::pin_async::{AsyncPortState, AsyncPortStateMutex, InterruptHandler, PinAsync};
 
 /// `PCA9554` "8-bit I2C-bus and SMBus I/O port with interrupt"
-pub struct Pca9554<M>(pub M, #[cfg(feature = "async")] pub RefCell<AsyncPortState>);
+pub struct Pca9554<M>(pub M, #[cfg(feature = "async")] pub AsyncPortStateMutex);
 
 /// `PCA9554A` "8-bit I2C-bus and SMBus I/O port with interrupt"
-pub struct Pca9554A<M>(pub M, #[cfg(feature = "async")] pub RefCell<AsyncPortState>);
+pub struct Pca9554A<M>(pub M, #[cfg(feature = "async")] pub AsyncPortStateMutex);
 
 impl<I2C> Pca9554<core::cell::RefCell<Driver<I2C>>>
 where
@@ -40,7 +38,7 @@ where
         Self(
             crate::PortMutex::create(Driver::new(i2c, false, a0, a1, a2)),
             #[cfg(feature = "async")]
-            RefCell::new(AsyncPortState::new()),
+            AsyncPortState::new_mutex(),
         )
     }
 
@@ -70,7 +68,9 @@ where
     ) -> Result<PartsAsync<'_, I2C, M>, <Driver<I2C> as crate::PortDriver>::Error> {
         // Read once so the async state won't see a spurious edge
         let initial_state = self.0.lock(|drv| drv.get(0xFF, 0))?;
-        self.1.borrow_mut().last_known_state = initial_state;
+        critical_section::with(|cs| {
+            self.1.borrow_ref_mut(cs).last_known_state = initial_state;
+        });
 
         Ok(PartsAsync {
             io0: PinAsync::new(crate::Pin::new(0, &self.0), &self.1, 0),
@@ -96,7 +96,7 @@ where
         Self(
             crate::PortMutex::create(Driver::new(i2c, true, a0, a1, a2)),
             #[cfg(feature = "async")]
-            RefCell::new(AsyncPortState::new()),
+            AsyncPortState::new_mutex(),
         )
     }
 
@@ -119,7 +119,9 @@ where
         &'_ mut self,
     ) -> Result<PartsAsync<'_, I2C, M>, <Driver<I2C> as crate::PortDriver>::Error> {
         let initial_state = self.0.lock(|drv| drv.get(0xFF, 0))?;
-        self.1.borrow_mut().last_known_state = initial_state;
+        critical_section::with(|cs| {
+            self.1.borrow_ref_mut(cs).last_known_state = initial_state;
+        });
 
         Ok(PartsAsync {
             io0: PinAsync::new(crate::Pin::new(0, &self.0), &self.1, 0),

--- a/src/dev/pca9554.rs
+++ b/src/dev/pca9554.rs
@@ -196,17 +196,21 @@ pub struct Driver<I2C> {
 }
 
 impl<I2C> Driver<I2C> {
-    pub fn new(i2c: I2C, is_a_variant: bool, a0: bool, a1: bool, a2: bool) -> Self {
+    pub fn new(mut i2c: I2C, is_a_variant: bool, a0: bool, a1: bool, a2: bool) -> Self
+    where
+        I2C: crate::I2cBus,
+    {
         let addr = if is_a_variant {
             0x38 | ((a2 as u8) << 2) | ((a1 as u8) << 1) | (a0 as u8)
         } else {
             0x20 | ((a2 as u8) << 2) | ((a1 as u8) << 1) | (a0 as u8)
         };
-        Self {
-            i2c,
-            out: 0xff,
-            addr,
-        }
+        // Read actual output register to sync shadow with hardware state.
+        // This prevents warm-reset glitches where retained hardware state
+        // differs from the default shadow value (0xFF).
+        // On read failure, fall back to 0xFF (PCA9554A power-on default).
+        let out = i2c.read_reg(addr, Regs::OutputPort0).unwrap_or(0xff);
+        Self { i2c, out, addr }
     }
 }
 
@@ -287,6 +291,7 @@ mod tests {
     #[test]
     fn pca9554a() {
         let expectations = [
+            mock_i2c::Transaction::write_read(0x39, vec![0x01], vec![0xff]),
             // set pin0 low and then high
             mock_i2c::Transaction::write(0x39, vec![0x01, 0xfe]),
             mock_i2c::Transaction::write(0x39, vec![0x01, 0xff]),
@@ -321,6 +326,7 @@ mod tests {
     #[test]
     fn pca9554() {
         let expectations = [
+            mock_i2c::Transaction::write_read(0x21, vec![0x01], vec![0xff]),
             // set pin0 low and then high
             mock_i2c::Transaction::write(0x21, vec![0x01, 0xfe]),
             mock_i2c::Transaction::write(0x21, vec![0x01, 0xff]),

--- a/src/dev/pca9702.rs
+++ b/src/dev/pca9702.rs
@@ -1,6 +1,6 @@
 //! Support for the `PCA9702` "8-Bit Input-Only Expander with SPI"
 //!
-//! Datasheet: https://www.nxp.com/docs/en/data-sheet/PCA9701_PCA9702.pdf
+//! Datasheet: <https://www.nxp.com/docs/en/data-sheet/PCA9701_PCA9702.pdf>
 //!
 //! The PCA9702 offers eight input pins, with an interrupt output that can be asserted when
 //! one or more of the inputs change state (enabled via the `INT_EN` pin). The device reads
@@ -18,12 +18,32 @@ use embedded_hal::spi::Operation;
 use crate::pin_async::{AsyncPortState, InterruptHandler, PinAsync};
 
 /// An 8-bit input-only expander with SPI, based on the PCA9702.
-pub struct Pca9702<M>(M);
+///
+/// Internally, this struct is a tuple:
+///
+/// - `.0` is your mutex-wrapped driver (`PortMutex<Driver<...>>`)
+/// - `.1` is an internal `RefCell<AsyncPortState>` used for optional async functionality
+///
+/// See [`split()`] for synchronous usage, or [`split_async()`] for async usage.
+pub struct Pca9702<M>(
+    /// The core driver behind a `PortMutex`, e.g. `RefCell<Driver<Pca9702Bus<SPI>>>`.
+    pub M,
+    /// Internal asynchronous state (used only if you call `split_async()`).
+    #[cfg(feature = "async")]
+    pub core::cell::RefCell<AsyncPortState>,
+    // If the "async" feature is not enabled, we simply don't store any
+    // extra field. For build consistency, let's conditionalize it:
+    #[cfg(not(feature = "async"))] (),
+);
 
 impl<SPI> Pca9702<core::cell::RefCell<Driver<Pca9702Bus<SPI>>>>
 where
     SPI: crate::SpiBus,
 {
+    /// Create a PCA9702 driver using a `core::cell::RefCell` as the mutex.
+    ///
+    /// This is the simplest constructor for no-std usage. If you'd prefer a different
+    /// mutex type, call the low-level [`with_mutex()`] constructor.
     pub fn new(bus: SPI) -> Self {
         Self::with_mutex(Pca9702Bus(bus))
     }
@@ -34,12 +54,24 @@ where
     B: Pca9702BusTrait,
     M: crate::PortMutex<Port = Driver<B>>,
 {
-    /// Create a PCA9702 driver with a user-supplied mutex type.
+    /// Create a PCA9702 driver with a user-supplied mutex type, e.g. a critical-section mutex or a std mutex.
     pub fn with_mutex(bus: B) -> Self {
-        Self(crate::PortMutex::create(Driver::new(bus)))
+        #[cfg(feature = "async")]
+        {
+            Self(
+                crate::PortMutex::create(Driver::new(bus)),
+                core::cell::RefCell::new(AsyncPortState::new()),
+            )
+        }
+
+        #[cfg(not(feature = "async"))]
+        {
+            // If async is disabled, there's no second field
+            Self(crate::PortMutex::create(Driver::new(bus)), ())
+        }
     }
 
-    /// Split this device into its 8 input pins.
+    /// Split this device into its 8 input pins (synchronous usage).
     ///
     /// All pins are always configured as inputs on PCA9702 hardware.
     pub fn split(&mut self) -> Parts<'_, B, M> {
@@ -55,32 +87,38 @@ where
         }
     }
 
-    /// Similar to `split()`, but returns asynchronous `PinAsync`s plus
-    /// an `InterruptHandler`.
+    /// **Async** split: returns 8 async input pins plus an interrupt handler.
     ///
-    /// Usage:
-    /// 1) Create a shared `AsyncPortState` (e.g. in a static or a RefCell).
-    /// 2) Call `split_async(...)` to get your pins and an interrupt handler.
-    /// 3) In your actual IRQ routine, call `interrupts.handle_interrupts()`.
+    /// Unlike the synchronous [`split()`] method, this method does:
+    /// 1. An initial read via SPI to synchronize the driver’s internal async-state with reality.
+    /// 2. Returns [`PartsAsync`] containing:
+    ///    - 8 asynchronous pins, each implementing [`embedded_hal_async::digital::Wait`].
+    ///    - An [`InterruptHandler`] to call from your real hardware ISR to wake any waiting tasks.
+    /// # Errors
+    /// Returns a bus error if the initial SPI read fails.
+    #[cfg(feature = "async")]
     pub fn split_async<'a>(
         &'a mut self,
-        async_state: &'a core::cell::RefCell<AsyncPortState>,
-    ) -> PartsAsync<'a, B, M> {
-        PartsAsync {
-            in0: PinAsync::new(Pin::new(0, &self.0), async_state, 0),
-            in1: PinAsync::new(Pin::new(1, &self.0), async_state, 1),
-            in2: PinAsync::new(Pin::new(2, &self.0), async_state, 2),
-            in3: PinAsync::new(Pin::new(3, &self.0), async_state, 3),
-            in4: PinAsync::new(Pin::new(4, &self.0), async_state, 4),
-            in5: PinAsync::new(Pin::new(5, &self.0), async_state, 5),
-            in6: PinAsync::new(Pin::new(6, &self.0), async_state, 6),
-            in7: PinAsync::new(Pin::new(7, &self.0), async_state, 7),
-            interrupts: InterruptHandler::new(&self.0, async_state),
-        }
+    ) -> Result<PartsAsync<'a, B, M>, B::BusError> {
+        // Perform an initial read so the async state doesn't see a "spurious edge" later.
+        let initial_state = self.0.lock(|drv| drv.get(0xFF, 0))?;
+        self.1.borrow_mut().last_known_state = initial_state;
+
+        Ok(PartsAsync {
+            in0: PinAsync::new(Pin::new(0, &self.0), &self.1, 0),
+            in1: PinAsync::new(Pin::new(1, &self.0), &self.1, 1),
+            in2: PinAsync::new(Pin::new(2, &self.0), &self.1, 2),
+            in3: PinAsync::new(Pin::new(3, &self.0), &self.1, 3),
+            in4: PinAsync::new(Pin::new(4, &self.0), &self.1, 4),
+            in5: PinAsync::new(Pin::new(5, &self.0), &self.1, 5),
+            in6: PinAsync::new(Pin::new(6, &self.0), &self.1, 6),
+            in7: PinAsync::new(Pin::new(7, &self.0), &self.1, 7),
+            interrupts: InterruptHandler::new(&self.0, &self.1),
+        })
     }
 }
 
-/// Container for all 8 input pins on the PCA9702.
+/// Container for all 8 input pins on the PCA9702 (synchronous).
 pub struct Parts<'a, B, M = core::cell::RefCell<Driver<B>>>
 where
     B: Pca9702BusTrait,
@@ -96,9 +134,8 @@ where
     pub in7: Pin<'a, crate::mode::Input, M>,
 }
 
-/// The async equivalent of the normal `Parts` struct.
-/// Each pin is always input, so each is a `PinAsync<mode::Input, M>`.
 #[cfg(feature = "async")]
+/// The async version of `Parts`, with `PinAsync`s plus an [`InterruptHandler`].
 pub struct PartsAsync<'a, B, M>
 where
     B: Pca9702BusTrait,
@@ -113,7 +150,8 @@ where
     pub in6: PinAsync<'a, crate::mode::Input, M>,
     pub in7: PinAsync<'a, crate::mode::Input, M>,
 
-    /// Interrupt handler to be called whenever the expander’s INT pin toggles.
+    /// Must be called from your real hardware interrupt to wake tasks that are waiting.
+    /// This is how the asynchronous wait logic is driven.
     pub interrupts: InterruptHandler<'a, M>,
 }
 
@@ -128,37 +166,38 @@ impl<B> Driver<B> {
     }
 }
 
-/// Trait for the underlying PCA9702 SPI bus. Simpler than e.g. MCP23S17
-/// because PCA9702 is read-only and has no register-based protocol.
+/// Trait for the underlying PCA9702 SPI bus.  
+/// PCA9702 is read-only (for inputs) with no registers, so `read_inputs()` is the only method.
 pub trait Pca9702BusTrait {
     type BusError;
-
-    /// Reads 8 bits from the device (which represent the state of inputs [in7..in0])
+    /// Reads 8 bits from the device (bits [in7..in0]).
     fn read_inputs(&mut self) -> Result<u8, Self::BusError>;
 }
 
 impl<B: Pca9702BusTrait> PortDriver for Driver<B> {
-    /// Our `Error` is a custom enum wrapping both bus errors and an unsupported-ops error.
     type Error = B::BusError;
 
-    /// PCA9702 is input-only, return an error here.
+    /// PCA9702 is input-only, so return an error.
     fn set(&mut self, _mask_high: u32, _mask_low: u32) -> Result<(), Self::Error> {
         panic!("PCA9702 is input-only, cannot set output states");
     }
 
-    /// PCA9702 is input-only, return an error here.
+    /// PCA9702 is input-only, so return an error.
     fn is_set(&mut self, _mask_high: u32, _mask_low: u32) -> Result<u32, Self::Error> {
         panic!("PCA9702 is input-only, cannot read back output states");
     }
 
-    /// Read the actual input bits from the PCA9702 device
+    /// Reads the actual input bits from the device.
+    /// `mask_high` bits are tested for “is the input high?”  
+    /// `mask_low` bits are tested for “is the input low?”  
+    /// The returned integer has `1`s in the positions that match.
     fn get(&mut self, mask_high: u32, mask_low: u32) -> Result<u32, Self::Error> {
         let val = self.bus.read_inputs()? as u32;
         Ok((val & mask_high) | (!val & mask_low))
     }
 }
 
-/// Bus wrapper type for PCA9702, implementing `Pca9702BusTrait`.
+/// Bus wrapper for PCA9702, implementing the trait that knows how to do the read.
 pub struct Pca9702Bus<SPI>(pub SPI);
 
 impl<SPI> Pca9702BusTrait for Pca9702Bus<SPI>
@@ -168,14 +207,13 @@ where
     type BusError = SPI::BusError;
 
     fn read_inputs(&mut self) -> Result<u8, Self::BusError> {
-        // PCA9702 wants a total of 8 SCLK rising edges to shift out the input data
-        // from SDOUT: The first rising edge latches the inputs, the next 8 edges
-        // shift them out.
+        // PCA9702 wants 8 SCLK rising edges to shift out the 8 input bits on SDOUT.
+        // The first rising edge also latches the input states. We'll just do
+        // a single TransferInPlace of one byte.
         let mut buffer = [0u8];
         let mut ops = [Operation::TransferInPlace(&mut buffer)];
         self.0.transaction(&mut ops)?;
-
-        // buffer[0] now holds bits [in7..in0]
+        // Now buffer[0] contains [in7..in0].
         Ok(buffer[0])
     }
 }
@@ -205,9 +243,8 @@ mod tests {
         let mut pca = Pca9702::new(spi_mock.clone());
         let pins = pca.split();
 
-        // For each call, the driver re-reads from SPI, returning 0xA5 each time.
-        // 0xA5 = 0b10100101 => in0=1, in1=0, in2=1, in3=0, in4=0, in5=1, in6=0, in7=1
-        assert_eq!(pins.in0.is_high().unwrap(), true); // LSB => 1
+        // 0xA5 = 0b1010_0101 => in0=1, in1=0, in2=1, in3=0, in4=0, in5=1, in6=0, in7=1
+        assert_eq!(pins.in0.is_high().unwrap(), true); // LSB
         assert_eq!(pins.in1.is_high().unwrap(), false);
         assert_eq!(pins.in2.is_high().unwrap(), true);
 

--- a/src/dev/pca9702.rs
+++ b/src/dev/pca9702.rs
@@ -15,16 +15,14 @@ use crate::{Pin, PortDriver, SpiBus};
 use embedded_hal::spi::Operation;
 
 #[cfg(feature = "async")]
-use crate::pin_async::{AsyncPortState, InterruptHandler, PinAsync};
-#[cfg(feature = "async")]
-use core::cell::RefCell;
+use crate::pin_async::{AsyncPortState, AsyncPortStateMutex, InterruptHandler, PinAsync};
 
 /// An 8-bit input-only expander with SPI, based on the PCA9702.
 ///
 /// Internally, this struct is a tuple:
 ///
 /// - `.0` is your mutex-wrapped driver (`PortMutex<Driver<...>>`)
-/// - `.1` is an internal `RefCell<AsyncPortState>` used for optional async functionality
+/// - `.1` is an internal `AsyncPortStateMutex` used for optional async functionality
 ///
 /// See [`split()`] for synchronous usage, or [`split_async()`] for async usage.
 pub struct Pca9702<M>(
@@ -32,7 +30,7 @@ pub struct Pca9702<M>(
     pub M,
     /// Internal asynchronous state (used only if you call `split_async()`).
     #[cfg(feature = "async")]
-    pub RefCell<AsyncPortState>,
+    pub AsyncPortStateMutex,
 );
 
 impl<SPI> Pca9702<core::cell::RefCell<Driver<Pca9702Bus<SPI>>>>
@@ -55,7 +53,7 @@ where
             Self(
                 crate::PortMutex::create(Driver::new(bus)),
                 #[cfg(feature = "async")]
-                RefCell::new(AsyncPortState::new()),
+                AsyncPortState::new_mutex(),
             )
         }
     }
@@ -87,7 +85,9 @@ where
     pub fn split_async<'a>(&'a mut self) -> Result<PartsAsync<'a, B, M>, B::BusError> {
         // Perform an initial read so the async state doesn't see a spurious edge
         let initial_state = self.0.lock(|drv| drv.get(0xFF, 0))?;
-        self.1.borrow_mut().last_known_state = initial_state;
+        critical_section::with(|cs| {
+            self.1.borrow_ref_mut(cs).last_known_state = initial_state;
+        });
 
         Ok(PartsAsync {
             in0: PinAsync::new(Pin::new(0, &self.0), &self.1, 0),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,9 @@ pub use mutex::PortMutex;
 pub use pin::Pin;
 pub use pin::PinError;
 
+#[cfg(feature = "async")]
+pub mod pin_async;
+
 pub(crate) use bus::I2cExt;
 pub(crate) use bus::SpiBus;
 pub(crate) use common::Direction;

--- a/src/pin_async.rs
+++ b/src/pin_async.rs
@@ -21,7 +21,7 @@ use core::future::Future;
 use core::pin::Pin;
 use core::sync::atomic::{AtomicU16, Ordering};
 use core::task::{Context, Poll, Waker};
-use embedded_hal::digital::ErrorType;
+use embedded_hal::digital::{ErrorType, InputPin};
 use embedded_hal_async::digital::Wait;
 use heapless::Vec;
 
@@ -229,14 +229,20 @@ where
             pin_index,
         }
     }
+}
 
-    /// Check synchronously if this pin is currently high.
-    pub fn is_high(&self) -> Result<bool, PinError<<M::Port as PortDriver>::Error>> {
+impl<'a, MODE, M> InputPin for PinAsync<'a, MODE, M>
+where
+    MODE: HasInput,
+    M: PortMutex,
+    M::Port: PortDriver,
+    <M::Port as PortDriver>::Error: core::fmt::Debug,
+{
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
         self.sync_pin.is_high()
     }
 
-    /// Check synchronously if this pin is currently low.
-    pub fn is_low(&self) -> Result<bool, PinError<<M::Port as PortDriver>::Error>> {
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
         self.sync_pin.is_low()
     }
 }

--- a/src/pin_async.rs
+++ b/src/pin_async.rs
@@ -1,0 +1,349 @@
+#[cfg(feature = "async")]
+use core::future::Future;
+#[cfg(feature = "async")]
+use core::pin::Pin;
+#[cfg(feature = "async")]
+use core::task::{Context, Poll, Waker};
+
+#[cfg(feature = "async")]
+use heapless::Vec;
+
+#[cfg(feature = "async")]
+use core::cell::RefCell;
+
+#[cfg(feature = "async")]
+use crate::common::PortDriver;
+#[cfg(feature = "async")]
+use crate::mode::HasInput;
+#[cfg(feature = "async")]
+use crate::mutex::PortMutex;
+#[cfg(feature = "async")]
+use crate::pin::{Pin as SyncPin, PinError};
+#[cfg(feature = "async")]
+use embedded_hal::digital::ErrorType;
+#[cfg(feature = "async")]
+use embedded_hal_async::digital::Wait;
+
+/// Maximum number of tasks that can wait on a single pin's events.
+#[cfg(feature = "async")]
+const MAX_WAKERS_PER_PIN: usize = 4;
+
+/// Possible wait conditions that a future might be waiting for.
+#[cfg(feature = "async")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WaitCondition {
+    High,
+    Low,
+    RisingEdge,
+    FallingEdge,
+    AnyEdge,
+}
+
+/// A single wait registration: which condition is the task waiting for, plus the Waker.
+#[cfg(feature = "async")]
+#[derive(Debug)]
+pub struct PinWaiter {
+    pub condition: WaitCondition,
+    pub waker: Waker,
+}
+
+/// Shared, interrupt-driven async state for a single port-expander chip.
+/// - Tracks last-known state (bitmask) of up to 32 pins
+/// - Maintains waker lists for each pin
+#[cfg(feature = "async")]
+pub struct AsyncPortState {
+    pub last_known_state: u32,
+    pub waiters: [Vec<PinWaiter, MAX_WAKERS_PER_PIN>; 32],
+}
+
+#[cfg(feature = "async")]
+impl AsyncPortState {
+    pub fn new() -> Self {
+        // Each of the 32 slots has an empty waker Vec
+        Self {
+            last_known_state: 0,
+            waiters: Default::default(),
+        }
+    }
+}
+
+/// The `InterruptHandler` is what you call when the hardware interrupt pin
+/// from the port-expander fires. It checks which pins changed, wakes tasks
+/// that were waiting for that change, and updates the `last_known_state`.
+#[cfg(feature = "async")]
+pub struct InterruptHandler<'a, M>
+where
+    M: PortMutex,
+    M::Port: PortDriver,
+{
+    port_mutex: &'a M,
+    async_state: &'a RefCell<AsyncPortState>,
+}
+
+#[cfg(feature = "async")]
+impl<'a, M> InterruptHandler<'a, M>
+where
+    M: PortMutex,
+    M::Port: PortDriver,
+{
+    pub fn new(port_mutex: &'a M, async_state: &'a RefCell<AsyncPortState>) -> Self {
+        Self {
+            port_mutex,
+            async_state,
+        }
+    }
+
+    /// Call this from your actual interrupt handler. It reads the current state
+    /// of all pins from the driver, compares with the old state, and wakes any tasks
+    /// that were waiting for these transitions.
+    pub fn handle_interrupts(&self) -> Result<(), <M::Port as PortDriver>::Error> {
+        // Acquire the driver to read all pin states
+        let new_state = self.port_mutex.lock(|drv| {
+            // We read 32 bits. For an 8/16-bit expander, you'd adapt accordingly,
+            // but typically you'd do a "get(0xFFFF_FFFF, 0)" to read which pins are high.
+            drv.get(0xFFFF_FFFF, 0)
+        })?;
+
+        let mut st = self.async_state.borrow_mut();
+        let old_state = st.last_known_state;
+        let changed = old_state ^ new_state;
+
+        if changed == 0 {
+            // No changes, so no tasks to wake
+            return Ok(());
+        }
+
+        // For each pin that changed, determine if it rose or fell, and wake tasks
+        for pin_idx in 0..32 {
+            let mask = 1 << pin_idx;
+            if (changed & mask) != 0 {
+                // This pin changed
+                let was_high = (old_state & mask) != 0;
+                let is_high = (new_state & mask) != 0;
+
+                let is_rising = !was_high && is_high;
+                let is_falling = was_high && !is_high;
+
+                let waiters = &mut st.waiters[pin_idx];
+                let mut i = 0;
+                while i < waiters.len() {
+                    let cond = waiters[i].condition;
+                    let wake_now = if is_rising {
+                        matches!(
+                            cond,
+                            WaitCondition::High
+                                | WaitCondition::RisingEdge
+                                | WaitCondition::AnyEdge
+                        )
+                    } else if is_falling {
+                        matches!(
+                            cond,
+                            WaitCondition::Low
+                                | WaitCondition::FallingEdge
+                                | WaitCondition::AnyEdge
+                        )
+                    } else {
+                        false
+                    };
+
+                    if wake_now {
+                        let w = waiters.remove(i);
+                        w.waker.wake();
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+        }
+
+        // Update last known
+        st.last_known_state = new_state;
+        Ok(())
+    }
+}
+
+/// An asynchronous pin type which implements [`embedded_hal_async::digital::Wait`].
+#[cfg(feature = "async")]
+pub struct PinAsync<'a, MODE, M>
+where
+    MODE: HasInput,
+    M: PortMutex,
+    M::Port: PortDriver,
+{
+    /// The underlying "synchronous" pin reference (same port driver).
+    pub sync_pin: SyncPin<'a, MODE, M>,
+
+    /// Reference to the shared async state for this entire port.
+    pub async_state: &'a RefCell<AsyncPortState>,
+
+    /// Which bit/pin index in the port. 0 => least-significant bit, etc.
+    pin_index: u8,
+}
+
+#[cfg(feature = "async")]
+impl<'a, MODE, M> PinAsync<'a, MODE, M>
+where
+    MODE: HasInput,
+    M: PortMutex,
+    M::Port: PortDriver,
+{
+    pub fn new(
+        sync_pin: SyncPin<'a, MODE, M>,
+        async_state: &'a RefCell<AsyncPortState>,
+        pin_index: u8,
+    ) -> Self {
+        Self {
+            sync_pin,
+            async_state,
+            pin_index,
+        }
+    }
+
+    /// **Synchronous** check if this pin is currently high.
+    /// Equivalent to `Pin::is_high()`.
+    pub fn is_high(&self) -> Result<bool, PinError<<M::Port as PortDriver>::Error>> {
+        self.sync_pin.is_high()
+    }
+
+    /// **Synchronous** check if this pin is currently low.
+    /// Equivalent to `Pin::is_low()`.
+    pub fn is_low(&self) -> Result<bool, PinError<<M::Port as PortDriver>::Error>> {
+        self.sync_pin.is_low()
+    }
+}
+
+#[cfg(feature = "async")]
+impl<'a, MODE, M> ErrorType for PinAsync<'a, MODE, M>
+where
+    MODE: HasInput,
+    M: PortMutex,
+    M::Port: PortDriver,
+    <M::Port as PortDriver>::Error: core::fmt::Debug,
+{
+    type Error = PinError<<M::Port as PortDriver>::Error>;
+}
+
+// The main trick: We do *not* store `&mut self` inside the future. Instead,
+// we create a small future that only references the minimal shared state.
+// That avoids the self-referential lifetime problem.
+#[cfg(feature = "async")]
+impl<'a, MODE, M> Wait for PinAsync<'a, MODE, M>
+where
+    MODE: HasInput,
+    M: PortMutex,
+    M::Port: PortDriver,
+    <M::Port as PortDriver>::Error: core::fmt::Debug,
+{
+    async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        // If already high, return immediately
+        if self.is_high()? {
+            return Ok(());
+        }
+        Ok(WaitForCondition {
+            pin_index: self.pin_index,
+            async_state: self.async_state,
+            condition: WaitCondition::High,
+            registered: false,
+        }
+        .await
+        .unwrap())
+    }
+
+    async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        if self.is_low()? {
+            return Ok(());
+        }
+        WaitForCondition {
+            pin_index: self.pin_index,
+            async_state: self.async_state,
+            condition: WaitCondition::Low,
+            registered: false,
+        }
+        .await
+        .map_err(|_| unreachable!())
+    }
+
+    async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        // Always wait for an actual transition
+        WaitForCondition {
+            pin_index: self.pin_index,
+            async_state: self.async_state,
+            condition: WaitCondition::RisingEdge,
+            registered: false,
+        }
+        .await
+        .map_err(|_| unreachable!())
+    }
+
+    async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        WaitForCondition {
+            pin_index: self.pin_index,
+            async_state: self.async_state,
+            condition: WaitCondition::FallingEdge,
+            registered: false,
+        }
+        .await
+        .map_err(|_| unreachable!())
+    }
+
+    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        WaitForCondition {
+            pin_index: self.pin_index,
+            async_state: self.async_state,
+            condition: WaitCondition::AnyEdge,
+            registered: false,
+        }
+        .await
+        .map_err(|_| unreachable!())
+    }
+}
+
+/// The internal future type for any pin-wait operation.
+/// We keep track of whether we've already registered a waker in the `AsyncPortState`.
+#[cfg(feature = "async")]
+struct WaitForCondition<'s> {
+    pin_index: u8,
+    async_state: &'s RefCell<AsyncPortState>,
+    condition: WaitCondition,
+    registered: bool,
+}
+
+#[cfg(feature = "async")]
+impl<'s> Future for WaitForCondition<'s> {
+    type Output = Result<(), PinError<core::convert::Infallible>>;
+    // ^ we use `PinError<Infallible>` because
+    //   after we've done the initial is_high/is_low check,
+    //   no more driver calls are made in the future (the driver calls happen in `handle_interrupts`).
+    //   So there's no I/O error from the device in the poll steps.
+    //   If you prefer, you can define your own "NoError" type or keep it flexible.
+    //   Typically we'd store the driver error type if we do repeated reads in poll,
+    //   but our design does not do that.
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let me = self.get_mut();
+
+        // Once we've put a waker in the waiters array, we are guaranteed
+        // that the interrupt handler will wake it up after a relevant edge or state change.
+        // So we only need to register once. Then we stay in Poll::Pending until woken.
+        if !me.registered {
+            let mut st = me.async_state.borrow_mut();
+            let pin_waiters = &mut st.waiters[me.pin_index as usize];
+
+            if pin_waiters.len() == pin_waiters.capacity() {
+                // In no-std + no-heap scenarios, we must either fail or panic.
+                panic!("No waker slots left for pin {}", me.pin_index);
+            }
+
+            pin_waiters
+                .push(PinWaiter {
+                    condition: me.condition,
+                    waker: cx.waker().clone(),
+                })
+                .expect("push should succeed due to capacity check");
+            me.registered = true;
+        }
+
+        // Not ready yet => wait for interrupt
+        Poll::Pending
+    }
+}

--- a/src/pin_async.rs
+++ b/src/pin_async.rs
@@ -18,6 +18,8 @@ use core::future::Future;
 #[cfg(feature = "async")]
 use core::pin::Pin;
 #[cfg(feature = "async")]
+use core::sync::atomic::{AtomicU16, Ordering};
+#[cfg(feature = "async")]
 use core::task::{Context, Poll, Waker};
 
 #[cfg(feature = "async")]
@@ -41,6 +43,8 @@ use embedded_hal_async::digital::Wait;
 #[cfg(feature = "async")]
 pub const MAX_WAKERS_PER_PIN: usize = 4;
 
+static NEXT_WAITER_ID: AtomicU16 = AtomicU16::new(1);
+
 /// Conditions for which a future might be waiting.
 #[cfg(feature = "async")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -52,10 +56,40 @@ pub enum WaitCondition {
     AnyEdge,
 }
 
+impl WaitCondition {
+    /// For levels (High/Low), is it satisfied by the current known state of the pin?
+    ///
+    /// For edge conditions, we never say "yes" up front. We want the *next* edge.
+    fn is_satisfied_immediately(self, current_pin_state: bool) -> bool {
+        match self {
+            WaitCondition::High => current_pin_state,
+            WaitCondition::Low => !current_pin_state,
+            WaitCondition::RisingEdge => false,
+            WaitCondition::FallingEdge => false,
+            WaitCondition::AnyEdge => false,
+        }
+    }
+
+    /// Does this condition match a transition from (was_high) to (is_high)?
+    fn matches_edge(self, was_high: bool, is_high: bool) -> bool {
+        let rising = !was_high && is_high;
+        let falling = was_high && !is_high;
+
+        match self {
+            WaitCondition::High => is_high,        // for an immediate "becomes high" check
+            WaitCondition::Low => !is_high,        // for an immediate "becomes low" check
+            WaitCondition::RisingEdge => rising,
+            WaitCondition::FallingEdge => falling,
+            WaitCondition::AnyEdge => rising || falling,
+        }
+    }
+}
+
 /// A wait registration for one task: which condition is awaited and the task's waker.
 #[cfg(feature = "async")]
 #[derive(Debug)]
 struct PinWaiter {
+    id: u16,
     condition: WaitCondition,
     waker: Waker,
 }
@@ -79,6 +113,12 @@ impl AsyncPortState {
     }
 }
 
+impl Default for AsyncPortState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Use this in your actual interrupt routine. It compares the new pin states
 /// vs. the old, wakes any tasks that match the changes, and updates
 /// `last_known_state`.
@@ -98,8 +138,7 @@ where
     M: PortMutex,
     M::Port: PortDriver,
 {
-    /// Construct a new `InterruptHandler`. Typically you store this somewhere
-    /// or pass it into your hardware IRQ routine.
+    /// Construct a new `InterruptHandler`. Store it or pass it into your hardware ISR.
     pub fn new(port_mutex: &'a M, async_state: &'a RefCell<AsyncPortState>) -> Self {
         Self {
             port_mutex,
@@ -131,33 +170,14 @@ where
                 let was_high = (old_state & mask) != 0;
                 let is_high = (new_state & mask) != 0;
 
-                let is_rising = !was_high && is_high;
-                let is_falling = was_high && !is_high;
-
-                let waiters = &mut st.waiters[pin_idx];
+                // We'll remove from the list any waiters whose condition is satisfied
+                // by the transition (was_high -> is_high).
+                let waiters_for_pin = &mut st.waiters[pin_idx];
                 let mut i = 0;
-                // Remove+wake any waiters whose condition is now satisfied.
-                while i < waiters.len() {
-                    let cond = waiters[i].condition;
-                    let wake_now = if is_rising {
-                        matches!(
-                            cond,
-                            WaitCondition::High
-                                | WaitCondition::RisingEdge
-                                | WaitCondition::AnyEdge
-                        )
-                    } else if is_falling {
-                        matches!(
-                            cond,
-                            WaitCondition::Low
-                                | WaitCondition::FallingEdge
-                                | WaitCondition::AnyEdge
-                        )
-                    } else {
-                        false
-                    };
-                    if wake_now {
-                        let w = waiters.remove(i);
+                while i < waiters_for_pin.len() {
+                    let cond = waiters_for_pin[i].condition;
+                    if cond.matches_edge(was_high, is_high) {
+                        let w = waiters_for_pin.remove(i);
                         w.waker.wake();
                     } else {
                         i += 1;
@@ -166,7 +186,7 @@ where
             }
         }
 
-        // Update the stored state.
+        // Update the stored state
         st.last_known_state = new_state;
         Ok(())
     }
@@ -182,8 +202,10 @@ where
 {
     /// The underlying synchronous pin reference.
     sync_pin: SyncPin<'a, MODE, M>,
+
     /// Reference to the shared async state for the entire port.
     async_state: &'a RefCell<AsyncPortState>,
+
     /// Which pin index (0..31).
     pin_index: u8,
 }
@@ -244,73 +266,73 @@ where
         if self.is_high()? {
             return Ok(());
         }
-        WaitForCondition {
-            pin_index: self.pin_index,
-            async_state: self.async_state,
-            condition: WaitCondition::High,
-            registered: false,
-        }
-        .await
-        .map_err(|_| unreachable!())
+        WaitForCondition::new(self.pin_index, self.async_state, WaitCondition::High).await.unwrap();
+        Ok(())
     }
 
     async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
         if self.is_low()? {
             return Ok(());
         }
-        WaitForCondition {
-            pin_index: self.pin_index,
-            async_state: self.async_state,
-            condition: WaitCondition::Low,
-            registered: false,
-        }
-        .await
-        .map_err(|_| unreachable!())
+        WaitForCondition::new(self.pin_index, self.async_state, WaitCondition::Low).await.unwrap();
+        Ok(())
     }
 
     async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
-        // Always wait for an actual transition
-        WaitForCondition {
-            pin_index: self.pin_index,
-            async_state: self.async_state,
-            condition: WaitCondition::RisingEdge,
-            registered: false,
-        }
-        .await
-        .map_err(|_| unreachable!())
+        WaitForCondition::new(self.pin_index, self.async_state, WaitCondition::RisingEdge).await.unwrap();
+        Ok(())
     }
 
     async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
-        WaitForCondition {
-            pin_index: self.pin_index,
-            async_state: self.async_state,
-            condition: WaitCondition::FallingEdge,
-            registered: false,
-        }
-        .await
-        .map_err(|_| unreachable!())
+        WaitForCondition::new(self.pin_index, self.async_state, WaitCondition::FallingEdge).await.unwrap();
+        Ok(())
     }
 
     async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
-        WaitForCondition {
-            pin_index: self.pin_index,
-            async_state: self.async_state,
-            condition: WaitCondition::AnyEdge,
-            registered: false,
-        }
-        .await
-        .map_err(|_| unreachable!())
+        WaitForCondition::new(self.pin_index, self.async_state, WaitCondition::AnyEdge).await.unwrap();
+        Ok(())
     }
 }
 
 /// The internal future type used by `PinAsync` wait methods. Once it registers
 /// a waker, it stays Pending until the interrupt handler removes and wakes it.
+///
+/// **Edge conditions** always wait for a *future* event.  
+/// **Level conditions** will short‐circuit if the current known state is already
+/// satisfied, otherwise they wait for the next time the interrupt handler sees
+/// that pin become that level (which is effectively a “level or edge”).
 #[cfg(feature = "async")]
 struct WaitForCondition<'s> {
     pin_index: u8,
     async_state: &'s RefCell<AsyncPortState>,
     condition: WaitCondition,
+    id: u16,
+
+    /// Have we already inserted ourselves into the waiters list?
     registered: bool,
+    /// Did we see that we are "done" (removed) during a wake?
+    done: bool,
+}
+
+#[cfg(feature = "async")]
+impl<'s> WaitForCondition<'s> {
+    fn new(
+        pin_index: u8,
+        async_state: &'s RefCell<AsyncPortState>,
+        condition: WaitCondition,
+    ) -> Self {
+        // Generate a new ID atomically
+        let id = NEXT_WAITER_ID.fetch_add(1, Ordering::Relaxed);
+
+        Self {
+            pin_index,
+            async_state,
+            condition,
+            id,
+            registered: false,
+            done: false,
+        }
+    }
 }
 
 #[cfg(feature = "async")]
@@ -322,39 +344,78 @@ impl<'s> Future for WaitForCondition<'s> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let me = self.get_mut();
 
-        // Only register once. The interrupt handler will wake us eventually.
-        if !me.registered {
-            let mut st = me.async_state.borrow_mut();
-            let pin_waiters = &mut st.waiters[me.pin_index as usize];
-
-            if pin_waiters.len() == pin_waiters.capacity() {
-                // panic is the only recourse if we run out of slots.
-                panic!("No waker slots left for pin {}", me.pin_index);
-            }
-
-            pin_waiters
-                .push(PinWaiter {
-                    condition: me.condition,
-                    waker: cx.waker().clone(),
-                })
-                .expect("push must succeed due to capacity check");
-            me.registered = true;
-
-            // Re-check if the condition might already be satisfied
-            // based on the last-known state in `st`.  This closes the race
-            // between the initial synchronous check and waker registration.
-            let mask = 1 << me.pin_index;
-            let is_high = (st.last_known_state & mask) != 0;
-            match me.condition {
-                WaitCondition::High if is_high => return Poll::Ready(Ok(())),
-                WaitCondition::Low if !is_high => return Poll::Ready(Ok(())),
-                // RisingEdge / FallingEdge / AnyEdge => we specifically want *future* transitions,
-                // so we do NOT return ready just for the pin currently being high or low.
-                _ => {}
-            }
+        // If we already determined "done", return Ready
+        if me.done {
+            return Poll::Ready(Ok(()));
         }
 
-        // We wait to be woken by `handle_interrupts()`.
-        Poll::Pending
+        let mut state = me.async_state.borrow_mut();
+        let mask = 1 << me.pin_index;
+        let current_pin_state = (state.last_known_state & mask) != 0;
+        let pin_waiters = &mut state.waiters[me.pin_index as usize];
+
+        // If this is a level condition (High/Low), check if it’s already satisfied
+        // by the current known state. If so, we can immediately return Ready.
+        // (For edges, we want *future* transitions, so do NOT short‐circuit.)
+        if !me.registered && me.condition.is_satisfied_immediately(current_pin_state) {
+            me.done = true;
+            return Poll::Ready(Ok(()));
+        }
+
+        // Otherwise we need to be in the waiter list, so we can be woken
+        // by the interrupt that sees the next transition or next time
+        // the pin becomes the desired level.
+
+        // Check if we are still in the list. If not, it means we got woken
+        // by the ISR (interrupt) which removed us. We must be done.
+        let pos = pin_waiters.iter().position(|pw| pw.id == me.id);
+
+        match (me.registered, pos) {
+            // Not registered yet => insert ourselves
+            (false, None) => {
+                // Attempt push
+                if pin_waiters.len() == pin_waiters.capacity() {
+                    panic!("No waker slots left");
+                }
+                pin_waiters
+                    .push(PinWaiter {
+                        id: me.id,
+                        condition: me.condition,
+                        waker: cx.waker().clone(),
+                    })
+                    .expect("push must succeed due to capacity check");
+                me.registered = true;
+                // We remain Pending
+                Poll::Pending
+            }
+
+            // We are registered, but the ISR removed us => we must have been triggered => done
+            (true, None) => {
+                me.done = true;
+                Poll::Ready(Ok(()))
+            }
+
+            // We are still in the list => update waker if changed, remain Pending
+            (_, Some(idx)) => {
+                let pw = &mut pin_waiters[idx];
+                if !pw.waker.will_wake(cx.waker()) {
+                    pw.waker = cx.waker().clone();
+                }
+                Poll::Pending
+            }
+        }
+    }
+}
+
+#[cfg(feature = "async")]
+impl<'s> Drop for WaitForCondition<'s> {
+    /// If the future is dropped before it is satisfied, remove from the list (if present).
+    fn drop(&mut self) {
+        let mut st = self.async_state.borrow_mut();
+        let waiters = &mut st.waiters[self.pin_index as usize];
+
+        if let Some(pos) = waiters.iter().position(|pw| pw.id == self.id) {
+            waiters.remove(pos);
+        }
     }
 }

--- a/src/pin_async.rs
+++ b/src/pin_async.rs
@@ -1,3 +1,18 @@
+//! Asynchronous pin-waiting support for port-expanders, using embedded-hal-async's
+//! [`digital::Wait`] trait.  
+//!
+//! This module is only built if the `"async"` feature is enabled. It provides:
+//! 1. A shared [`AsyncPortState`] which tracks last-known pin states and holds waiters.
+//! 2. An [`InterruptHandler`] to call from your real hardware interrupt routine.
+//! 3. A [`PinAsync`] type implementing `embedded_hal_async::digital::Wait`.
+//!
+//! **Concurrency caution**: If your interrupt can fire while tasks are registering
+//! new wakers (i.e. calling `wait_for_*`), you must ensure no double borrowing of
+//! `AsyncPortState`. For example, wrap it (and the driver) in a critical-section
+//! or the same mutex. Failing to do so can cause runtime panics in no-std.
+
+#[cfg(feature = "async")]
+use core::cell::RefCell;
 #[cfg(feature = "async")]
 use core::future::Future;
 #[cfg(feature = "async")]
@@ -7,9 +22,6 @@ use core::task::{Context, Poll, Waker};
 
 #[cfg(feature = "async")]
 use heapless::Vec;
-
-#[cfg(feature = "async")]
-use core::cell::RefCell;
 
 #[cfg(feature = "async")]
 use crate::common::PortDriver;
@@ -25,10 +37,11 @@ use embedded_hal::digital::ErrorType;
 use embedded_hal_async::digital::Wait;
 
 /// Maximum number of tasks that can wait on a single pin's events.
+/// Increase this if you expect more concurrency.
 #[cfg(feature = "async")]
-const MAX_WAKERS_PER_PIN: usize = 4;
+pub const MAX_WAKERS_PER_PIN: usize = 4;
 
-/// Possible wait conditions that a future might be waiting for.
+/// Conditions for which a future might be waiting.
 #[cfg(feature = "async")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WaitCondition {
@@ -39,12 +52,12 @@ pub enum WaitCondition {
     AnyEdge,
 }
 
-/// A single wait registration: which condition is the task waiting for, plus the Waker.
+/// A wait registration for one task: which condition is awaited and the task's waker.
 #[cfg(feature = "async")]
 #[derive(Debug)]
-pub struct PinWaiter {
-    pub condition: WaitCondition,
-    pub waker: Waker,
+struct PinWaiter {
+    condition: WaitCondition,
+    waker: Waker,
 }
 
 /// Shared, interrupt-driven async state for a single port-expander chip.
@@ -53,13 +66,12 @@ pub struct PinWaiter {
 #[cfg(feature = "async")]
 pub struct AsyncPortState {
     pub last_known_state: u32,
-    pub waiters: [Vec<PinWaiter, MAX_WAKERS_PER_PIN>; 32],
+    waiters: [Vec<PinWaiter, MAX_WAKERS_PER_PIN>; 32],
 }
 
 #[cfg(feature = "async")]
 impl AsyncPortState {
     pub fn new() -> Self {
-        // Each of the 32 slots has an empty waker Vec
         Self {
             last_known_state: 0,
             waiters: Default::default(),
@@ -67,9 +79,9 @@ impl AsyncPortState {
     }
 }
 
-/// The `InterruptHandler` is what you call when the hardware interrupt pin
-/// from the port-expander fires. It checks which pins changed, wakes tasks
-/// that were waiting for that change, and updates the `last_known_state`.
+/// Use this in your actual interrupt routine. It compares the new pin states
+/// vs. the old, wakes any tasks that match the changes, and updates
+/// `last_known_state`.
 #[cfg(feature = "async")]
 pub struct InterruptHandler<'a, M>
 where
@@ -86,6 +98,8 @@ where
     M: PortMutex,
     M::Port: PortDriver,
 {
+    /// Construct a new `InterruptHandler`. Typically you store this somewhere
+    /// or pass it into your hardware IRQ routine.
     pub fn new(port_mutex: &'a M, async_state: &'a RefCell<AsyncPortState>) -> Self {
         Self {
             port_mutex,
@@ -93,31 +107,27 @@ where
         }
     }
 
-    /// Call this from your actual interrupt handler. It reads the current state
-    /// of all pins from the driver, compares with the old state, and wakes any tasks
-    /// that were waiting for these transitions.
+    /// Called from your hardware ISR. Reads the new pin states, compares with old,
+    /// wakes tasks that match, updates `last_known_state`.
     pub fn handle_interrupts(&self) -> Result<(), <M::Port as PortDriver>::Error> {
-        // Acquire the driver to read all pin states
-        let new_state = self.port_mutex.lock(|drv| {
-            // We read 32 bits. For an 8/16-bit expander, you'd adapt accordingly,
-            // but typically you'd do a "get(0xFFFF_FFFF, 0)" to read which pins are high.
-            drv.get(0xFFFF_FFFF, 0)
-        })?;
+        // Read the current state. For an 8- or 16-bit expander, you'd typically do
+        // something like get(0xFF,0) or get(0xFFFF,0). Using 0xFFFF_FFFF to read “all 32 pins”
+        // is a general approach if the driver supports up to 32.
+        let new_state = self.port_mutex.lock(|drv| drv.get(0xFFFF_FFFF, 0))?;
 
         let mut st = self.async_state.borrow_mut();
         let old_state = st.last_known_state;
         let changed = old_state ^ new_state;
 
         if changed == 0 {
-            // No changes, so no tasks to wake
+            // Nothing changed; no tasks to wake.
             return Ok(());
         }
 
-        // For each pin that changed, determine if it rose or fell, and wake tasks
+        // For each pin that changed, figure out if it rose or fell.
         for pin_idx in 0..32 {
             let mask = 1 << pin_idx;
             if (changed & mask) != 0 {
-                // This pin changed
                 let was_high = (old_state & mask) != 0;
                 let is_high = (new_state & mask) != 0;
 
@@ -126,6 +136,7 @@ where
 
                 let waiters = &mut st.waiters[pin_idx];
                 let mut i = 0;
+                // Remove+wake any waiters whose condition is now satisfied.
                 while i < waiters.len() {
                     let cond = waiters[i].condition;
                     let wake_now = if is_rising {
@@ -145,7 +156,6 @@ where
                     } else {
                         false
                     };
-
                     if wake_now {
                         let w = waiters.remove(i);
                         w.waker.wake();
@@ -156,13 +166,13 @@ where
             }
         }
 
-        // Update last known
+        // Update the stored state.
         st.last_known_state = new_state;
         Ok(())
     }
 }
 
-/// An asynchronous pin type which implements [`embedded_hal_async::digital::Wait`].
+/// Asynchronous pin object implementing [`embedded_hal_async::digital::Wait`].
 #[cfg(feature = "async")]
 pub struct PinAsync<'a, MODE, M>
 where
@@ -170,13 +180,11 @@ where
     M: PortMutex,
     M::Port: PortDriver,
 {
-    /// The underlying "synchronous" pin reference (same port driver).
-    pub sync_pin: SyncPin<'a, MODE, M>,
-
-    /// Reference to the shared async state for this entire port.
-    pub async_state: &'a RefCell<AsyncPortState>,
-
-    /// Which bit/pin index in the port. 0 => least-significant bit, etc.
+    /// The underlying synchronous pin reference.
+    sync_pin: SyncPin<'a, MODE, M>,
+    /// Reference to the shared async state for the entire port.
+    async_state: &'a RefCell<AsyncPortState>,
+    /// Which pin index (0..31).
     pin_index: u8,
 }
 
@@ -187,6 +195,8 @@ where
     M: PortMutex,
     M::Port: PortDriver,
 {
+    /// Constructs a `PinAsync` from a sync pin plus a reference to the shared `AsyncPortState`.
+    /// The `pin_index` must match the bit number used in the underlying driver.
     pub fn new(
         sync_pin: SyncPin<'a, MODE, M>,
         async_state: &'a RefCell<AsyncPortState>,
@@ -199,14 +209,12 @@ where
         }
     }
 
-    /// **Synchronous** check if this pin is currently high.
-    /// Equivalent to `Pin::is_high()`.
+    /// Check synchronously if this pin is currently high.
     pub fn is_high(&self) -> Result<bool, PinError<<M::Port as PortDriver>::Error>> {
         self.sync_pin.is_high()
     }
 
-    /// **Synchronous** check if this pin is currently low.
-    /// Equivalent to `Pin::is_low()`.
+    /// Check synchronously if this pin is currently low.
     pub fn is_low(&self) -> Result<bool, PinError<<M::Port as PortDriver>::Error>> {
         self.sync_pin.is_low()
     }
@@ -223,9 +231,6 @@ where
     type Error = PinError<<M::Port as PortDriver>::Error>;
 }
 
-// The main trick: We do *not* store `&mut self` inside the future. Instead,
-// we create a small future that only references the minimal shared state.
-// That avoids the self-referential lifetime problem.
 #[cfg(feature = "async")]
 impl<'a, MODE, M> Wait for PinAsync<'a, MODE, M>
 where
@@ -235,18 +240,17 @@ where
     <M::Port as PortDriver>::Error: core::fmt::Debug,
 {
     async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
-        // If already high, return immediately
         if self.is_high()? {
             return Ok(());
         }
-        Ok(WaitForCondition {
+        WaitForCondition {
             pin_index: self.pin_index,
             async_state: self.async_state,
             condition: WaitCondition::High,
             registered: false,
         }
         .await
-        .unwrap())
+        .map_err(|_| unreachable!())
     }
 
     async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
@@ -298,8 +302,8 @@ where
     }
 }
 
-/// The internal future type for any pin-wait operation.
-/// We keep track of whether we've already registered a waker in the `AsyncPortState`.
+/// The internal future type used by `PinAsync` wait methods. Once it registers
+/// a waker, it stays Pending until the interrupt handler removes and wakes it.
 #[cfg(feature = "async")]
 struct WaitForCondition<'s> {
     pin_index: u8,
@@ -310,27 +314,20 @@ struct WaitForCondition<'s> {
 
 #[cfg(feature = "async")]
 impl<'s> Future for WaitForCondition<'s> {
+    // Once we've performed the initial synchronous check, no more I/O occurs in poll(),
+    // so we can't produce a bus error. We use `PinError<core::convert::Infallible>`.
     type Output = Result<(), PinError<core::convert::Infallible>>;
-    // ^ we use `PinError<Infallible>` because
-    //   after we've done the initial is_high/is_low check,
-    //   no more driver calls are made in the future (the driver calls happen in `handle_interrupts`).
-    //   So there's no I/O error from the device in the poll steps.
-    //   If you prefer, you can define your own "NoError" type or keep it flexible.
-    //   Typically we'd store the driver error type if we do repeated reads in poll,
-    //   but our design does not do that.
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let me = self.get_mut();
 
-        // Once we've put a waker in the waiters array, we are guaranteed
-        // that the interrupt handler will wake it up after a relevant edge or state change.
-        // So we only need to register once. Then we stay in Poll::Pending until woken.
+        // Only register once. The interrupt handler will wake us eventually.
         if !me.registered {
             let mut st = me.async_state.borrow_mut();
             let pin_waiters = &mut st.waiters[me.pin_index as usize];
 
             if pin_waiters.len() == pin_waiters.capacity() {
-                // In no-std + no-heap scenarios, we must either fail or panic.
+                // In no-std, panic is often the only recourse if we run out of slots.
                 panic!("No waker slots left for pin {}", me.pin_index);
             }
 
@@ -339,11 +336,11 @@ impl<'s> Future for WaitForCondition<'s> {
                     condition: me.condition,
                     waker: cx.waker().clone(),
                 })
-                .expect("push should succeed due to capacity check");
+                .expect("push must succeed due to capacity check");
             me.registered = true;
         }
 
-        // Not ready yet => wait for interrupt
+        // We wait to be woken by `handle_interrupts()`.
         Poll::Pending
     }
 }

--- a/src/pin_async.rs
+++ b/src/pin_async.rs
@@ -21,7 +21,6 @@ use core::future::Future;
 use core::pin::Pin;
 use core::sync::atomic::{AtomicU16, Ordering};
 use core::task::{Context, Poll, Waker};
-use embedded_hal::digital::{ErrorType, InputPin};
 use embedded_hal_async::digital::Wait;
 use heapless::Vec;
 
@@ -231,7 +230,7 @@ where
     }
 }
 
-impl<'a, MODE, M> InputPin for PinAsync<'a, MODE, M>
+impl<'a, MODE, M> embedded_hal::digital::InputPin for PinAsync<'a, MODE, M>
 where
     MODE: HasInput,
     M: PortMutex,
@@ -247,7 +246,7 @@ where
     }
 }
 
-impl<'a, MODE, M> ErrorType for PinAsync<'a, MODE, M>
+impl<'a, MODE, M> embedded_hal::digital::ErrorType for PinAsync<'a, MODE, M>
 where
     MODE: HasInput,
     M: PortMutex,
@@ -255,6 +254,22 @@ where
     <M::Port as PortDriver>::Error: core::fmt::Debug,
 {
     type Error = PinError<<M::Port as PortDriver>::Error>;
+}
+
+impl<'a, MODE, M> embedded_hal_async::digital::InputPin for PinAsync<'a, MODE, M>
+where
+    MODE: HasInput,
+    M: PortMutex,
+    M::Port: PortDriver,
+    <M::Port as PortDriver>::Error: core::fmt::Debug,
+{
+    async fn is_high(&mut self) -> Result<bool, Self::Error> {
+        self.sync_pin.is_high()
+    }
+
+    async fn is_low(&mut self) -> Result<bool, Self::Error> {
+        self.sync_pin.is_low()
+    }
 }
 
 impl<'a, MODE, M> Wait for PinAsync<'a, MODE, M>
@@ -266,7 +281,7 @@ where
 {
     async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
         // If already high, return immediately
-        if self.is_high()? {
+        if <Self as embedded_hal::digital::InputPin>::is_high(self)? {
             return Ok(());
         }
         WaitForCondition::new(self.pin_index, self.async_state, WaitCondition::High)
@@ -276,7 +291,7 @@ where
     }
 
     async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
-        if self.is_low()? {
+        if <Self as embedded_hal::digital::InputPin>::is_low(self)? {
             return Ok(());
         }
         WaitForCondition::new(self.pin_index, self.async_state, WaitCondition::Low)

--- a/src/pin_async.rs
+++ b/src/pin_async.rs
@@ -21,8 +21,12 @@ use core::future::Future;
 use core::pin::Pin;
 use core::sync::atomic::{AtomicU16, Ordering};
 use core::task::{Context, Poll, Waker};
+use critical_section::Mutex;
 use embedded_hal_async::digital::Wait;
 use heapless::Vec;
+
+/// Thread-safe wrapper for AsyncPortState.
+pub type AsyncPortStateMutex = Mutex<RefCell<AsyncPortState>>;
 
 /// Maximum number of tasks that can wait on a single pin's events.
 /// Increase this if you expect more concurrency.
@@ -92,6 +96,11 @@ impl AsyncPortState {
             waiters: Default::default(),
         }
     }
+
+    /// Create a new AsyncPortState wrapped in a critical-section Mutex.
+    pub fn new_mutex() -> AsyncPortStateMutex {
+        Mutex::new(RefCell::new(Self::new()))
+    }
 }
 
 impl Default for AsyncPortState {
@@ -109,7 +118,7 @@ where
     M::Port: PortDriver,
 {
     port_mutex: &'a M,
-    async_state: &'a RefCell<AsyncPortState>,
+    async_state: &'a AsyncPortStateMutex,
 }
 
 impl<'a, M> InterruptHandler<'a, M>
@@ -118,7 +127,7 @@ where
     M::Port: PortDriver,
 {
     /// Construct a new `InterruptHandler`. Store it or pass it into your hardware ISR.
-    pub fn new(port_mutex: &'a M, async_state: &'a RefCell<AsyncPortState>) -> Self {
+    pub fn new(port_mutex: &'a M, async_state: &'a AsyncPortStateMutex) -> Self {
         Self {
             port_mutex,
             async_state,
@@ -129,44 +138,47 @@ where
     /// wakes tasks that match, updates `last_known_state`.
     pub fn handle_interrupts(&self) -> Result<(), <M::Port as PortDriver>::Error> {
         // Read the current state. For an 8- or 16-bit expander, you'd typically do
-        // something like get(0xFF,0) or get(0xFFFF,0). Using 0xFFFF_FFFF to read “all 32 pins”
+        // something like get(0xFF,0) or get(0xFFFF,0). Using 0xFFFF_FFFF to read "all 32 pins"
         // is a general approach if the driver supports up to 32.
         let new_state = self.port_mutex.lock(|drv| drv.get(0xFFFF_FFFF, 0))?;
 
-        let mut st = self.async_state.borrow_mut();
-        let old_state = st.last_known_state;
-        let changed = old_state ^ new_state;
+        critical_section::with(|cs| {
+            let mut st = self.async_state.borrow_ref_mut(cs);
+            let old_state = st.last_known_state;
+            let changed = old_state ^ new_state;
 
-        if changed == 0 {
-            // Nothing changed; no tasks to wake.
-            return Ok(());
-        }
+            if changed == 0 {
+                // Nothing changed; no tasks to wake.
+                return;
+            }
 
-        // For each pin that changed, figure out if it rose or fell.
-        for pin_idx in 0..32 {
-            let mask = 1 << pin_idx;
-            if (changed & mask) != 0 {
-                let was_high = (old_state & mask) != 0;
-                let is_high = (new_state & mask) != 0;
+            // For each pin that changed, figure out if it rose or fell.
+            for pin_idx in 0..32 {
+                let mask = 1 << pin_idx;
+                if (changed & mask) != 0 {
+                    let was_high = (old_state & mask) != 0;
+                    let is_high = (new_state & mask) != 0;
 
-                // We'll remove from the list any waiters whose condition is satisfied
-                // by the transition (was_high -> is_high).
-                let waiters_for_pin = &mut st.waiters[pin_idx];
-                let mut i = 0;
-                while i < waiters_for_pin.len() {
-                    let cond = waiters_for_pin[i].condition;
-                    if cond.matches_edge(was_high, is_high) {
-                        let w = waiters_for_pin.remove(i);
-                        w.waker.wake();
-                    } else {
-                        i += 1;
+                    // We'll remove from the list any waiters whose condition is satisfied
+                    // by the transition (was_high -> is_high).
+                    let waiters_for_pin = &mut st.waiters[pin_idx];
+                    let mut i = 0;
+                    while i < waiters_for_pin.len() {
+                        let cond = waiters_for_pin[i].condition;
+                        if cond.matches_edge(was_high, is_high) {
+                            let w = waiters_for_pin.remove(i);
+                            w.waker.wake();
+                        } else {
+                            i += 1;
+                        }
                     }
                 }
             }
-        }
 
-        // Update the stored state
-        st.last_known_state = new_state;
+            // Update the stored state
+            st.last_known_state = new_state;
+        });
+
         Ok(())
     }
 }
@@ -182,7 +194,7 @@ where
     sync_pin: SyncPin<'a, MODE, M>,
 
     /// Reference to the shared async state for the entire port.
-    async_state: &'a RefCell<AsyncPortState>,
+    async_state: &'a AsyncPortStateMutex,
 
     /// Which pin index (0..31).
     pin_index: u8,
@@ -219,7 +231,7 @@ where
     /// The `pin_index` must match the bit number used in the underlying driver.
     pub fn new(
         sync_pin: SyncPin<'a, MODE, M>,
-        async_state: &'a RefCell<AsyncPortState>,
+        async_state: &'a AsyncPortStateMutex,
         pin_index: u8,
     ) -> Self {
         Self {
@@ -325,13 +337,13 @@ where
 /// The internal future type used by `PinAsync` wait methods. Once it registers
 /// a waker, it stays Pending until the interrupt handler removes and wakes it.
 ///
-/// **Edge conditions** always wait for a *future* event.  
+/// **Edge conditions** always wait for a *future* event.
 /// **Level conditions** will short‐circuit if the current known state is already
 /// satisfied, otherwise they wait for the next time the interrupt handler sees
-/// that pin become that level (which is effectively a “level or edge”).
+/// that pin become that level (which is effectively a "level or edge").
 struct WaitForCondition<'s> {
     pin_index: u8,
-    async_state: &'s RefCell<AsyncPortState>,
+    async_state: &'s AsyncPortStateMutex,
     condition: WaitCondition,
     id: u16,
 
@@ -344,7 +356,7 @@ struct WaitForCondition<'s> {
 impl<'s> WaitForCondition<'s> {
     fn new(
         pin_index: u8,
-        async_state: &'s RefCell<AsyncPortState>,
+        async_state: &'s AsyncPortStateMutex,
         condition: WaitCondition,
     ) -> Self {
         // Generate a new ID atomically
@@ -374,72 +386,76 @@ impl<'s> Future for WaitForCondition<'s> {
             return Poll::Ready(Ok(()));
         }
 
-        let mut state = me.async_state.borrow_mut();
-        let mask = 1 << me.pin_index;
-        let current_pin_state = (state.last_known_state & mask) != 0;
-        let pin_waiters = &mut state.waiters[me.pin_index as usize];
+        critical_section::with(|cs| {
+            let mut state = me.async_state.borrow_ref_mut(cs);
+            let mask = 1 << me.pin_index;
+            let current_pin_state = (state.last_known_state & mask) != 0;
+            let pin_waiters = &mut state.waiters[me.pin_index as usize];
 
-        // If this is a level condition (High/Low), check if it’s already satisfied
-        // by the current known state. If so, we can immediately return Ready.
-        // (For edges, we want *future* transitions, so do NOT short‐circuit.)
-        if !me.registered && me.condition.is_satisfied_immediately(current_pin_state) {
-            me.done = true;
-            return Poll::Ready(Ok(()));
-        }
-
-        // Otherwise we need to be in the waiter list, so we can be woken
-        // by the interrupt that sees the next transition or next time
-        // the pin becomes the desired level.
-
-        // Check if we are still in the list. If not, it means we got woken
-        // by the ISR (interrupt) which removed us. We must be done.
-        let pos = pin_waiters.iter().position(|pw| pw.id == me.id);
-
-        match (me.registered, pos) {
-            // Not registered yet => insert ourselves
-            (false, None) => {
-                // Attempt push
-                if pin_waiters.len() == pin_waiters.capacity() {
-                    panic!("No waker slots left");
-                }
-                pin_waiters
-                    .push(PinWaiter {
-                        id: me.id,
-                        condition: me.condition,
-                        waker: cx.waker().clone(),
-                    })
-                    .expect("push must succeed due to capacity check");
-                me.registered = true;
-                // We remain Pending
-                Poll::Pending
-            }
-
-            // We are registered, but the ISR removed us => we must have been triggered => done
-            (true, None) => {
+            // If this is a level condition (High/Low), check if it's already satisfied
+            // by the current known state. If so, we can immediately return Ready.
+            // (For edges, we want *future* transitions, so do NOT short‐circuit.)
+            if !me.registered && me.condition.is_satisfied_immediately(current_pin_state) {
                 me.done = true;
-                Poll::Ready(Ok(()))
+                return Poll::Ready(Ok(()));
             }
 
-            // We are still in the list => update waker if changed, remain Pending
-            (_, Some(idx)) => {
-                let pw = &mut pin_waiters[idx];
-                if !pw.waker.will_wake(cx.waker()) {
-                    pw.waker = cx.waker().clone();
+            // Otherwise we need to be in the waiter list, so we can be woken
+            // by the interrupt that sees the next transition or next time
+            // the pin becomes the desired level.
+
+            // Check if we are still in the list. If not, it means we got woken
+            // by the ISR (interrupt) which removed us. We must be done.
+            let pos = pin_waiters.iter().position(|pw| pw.id == me.id);
+
+            match (me.registered, pos) {
+                // Not registered yet => insert ourselves
+                (false, None) => {
+                    // Attempt push
+                    if pin_waiters.len() == pin_waiters.capacity() {
+                        panic!("No waker slots left");
+                    }
+                    pin_waiters
+                        .push(PinWaiter {
+                            id: me.id,
+                            condition: me.condition,
+                            waker: cx.waker().clone(),
+                        })
+                        .expect("push must succeed due to capacity check");
+                    me.registered = true;
+                    // We remain Pending
+                    Poll::Pending
                 }
-                Poll::Pending
+
+                // We are registered, but the ISR removed us => we must have been triggered => done
+                (true, None) => {
+                    me.done = true;
+                    Poll::Ready(Ok(()))
+                }
+
+                // We are still in the list => update waker if changed, remain Pending
+                (_, Some(idx)) => {
+                    let pw = &mut pin_waiters[idx];
+                    if !pw.waker.will_wake(cx.waker()) {
+                        pw.waker = cx.waker().clone();
+                    }
+                    Poll::Pending
+                }
             }
-        }
+        })
     }
 }
 
 impl<'s> Drop for WaitForCondition<'s> {
     /// If the future is dropped before it is satisfied, remove from the list (if present).
     fn drop(&mut self) {
-        let mut st = self.async_state.borrow_mut();
-        let waiters = &mut st.waiters[self.pin_index as usize];
+        critical_section::with(|cs| {
+            let mut st = self.async_state.borrow_ref_mut(cs);
+            let waiters = &mut st.waiters[self.pin_index as usize];
 
-        if let Some(pos) = waiters.iter().position(|pw| pw.id == self.id) {
-            waiters.remove(pos);
-        }
+            if let Some(pos) = waiters.iter().position(|pw| pw.id == self.id) {
+                waiters.remove(pos);
+            }
+        });
     }
 }


### PR DESCRIPTION
This pull request adds asynchronous pin-waiting support using [embedded-hal-async](https://github.com/rust-embedded/embedded-hal/tree/master/embedded-hal-async) to the port-expander crate. It introduces a new PinAsync type that implements digital::Wait, along with a shared AsyncPortState and an InterruptHandler to be invoked from a hardware ISR.

Its a WIP and in its current state works for my specific use-case - So far, I've only provided async support for the PCA9702 driver. I plan to extend this to other drivers (e.g., PCA9554A and MCP23S17) which I am actively using in my own projects.

@Rahix previously mentioned not wanting to force embedded-hal-async on users. My intention is not to force an async model on all users, but rather to provide an additional optional layer for those who do want to rely on embedded-hal-async for pin interrupt handling. The current approach still keeps the “wait for interrupt” part separate from the actual hardware ISR. Instead, the crate user can call into the InterruptHandler via their own ISR or background task, whichever pattern they choose. The interrupt handling logic remains in their domain.

I look forward to feedback and any suggestions on how to better integrate or scope this functionality. Even if this PR ends up serving only as a reference implementation or a starting point for future work, I hope it can be useful as an example of how embedded-hal-async might be integrated in this crate. Let me know what you think—happy to discuss other design approaches as well!