### PR TITLE
add pub use for `PinError`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ pub use multi::read_multiple;
 pub use multi::write_multiple;
 pub use mutex::PortMutex;
 pub use pin::Pin;
+pub use pin::PinError;
 
 pub(crate) use bus::I2cExt;
 pub(crate) use bus::SpiBus;


### PR DESCRIPTION
I found that `PinError` isn't public which makes I hard to handle the error. 